### PR TITLE
Add system-level messages with response control and feed suppression

### DIFF
--- a/backend/agents/graphql/mutations.py
+++ b/backend/agents/graphql/mutations.py
@@ -226,6 +226,13 @@ class AgentMutation:
                     claude_md.encode("utf-8"),
                     "/home/agent/CLAUDE.md",
                 )
+                from agents.services.comms import send_system_message
+                await send_system_message(
+                    str(agent.id),
+                    "Your instructions have been updated. Re-read CLAUDE.md for the latest.",
+                    response_policy="discard",
+                    trigger="instruction_update",
+                )
             except Exception:
                 pass  # Agent may be stopped — DB is updated, will take effect on restart
 
@@ -306,6 +313,14 @@ class AgentMutation:
             "model", "role", "mcp_servers", "config_snapshot",
         ])
 
+        from agents.services.comms import send_system_message
+        await send_system_message(
+            str(agent.id),
+            "Your configuration has been updated (model, role, or MCP servers changed). A restart is in progress.",
+            response_policy="discard",
+            trigger="config_change",
+        )
+
         return await hard_restart_agent(str(agent.id))
 
     # --- Project Secrets ---
@@ -381,6 +396,7 @@ async def _push_secrets_for_project(project) -> None:
     """Push merged secrets to all running agents in a project."""
     from agents.models import Agent, AgentStatus
     from agents.runtimes import get_runtime
+    from agents.services.comms import send_system_message
     from agents.services.lifecycle import resolve_agent_secrets
     from agents.services.provision import push_secrets_to_agent
 
@@ -401,6 +417,12 @@ async def _push_secrets_for_project(project) -> None:
                 runtime = get_runtime(agent.runtime)
                 await push_secrets_to_agent(
                     runtime, agent.sandbox_id, agent, secret_envs,
+                )
+                await send_system_message(
+                    str(agent.id),
+                    "Project secrets have been updated. New values are available in your environment.",
+                    response_policy="discard",
+                    trigger="secret_rotation",
                 )
         except Exception:
             pass  # Best-effort

--- a/backend/agents/services/comms.py
+++ b/backend/agents/services/comms.py
@@ -68,6 +68,64 @@ def _atomic_enqueue(agent_id: str, input_msg: dict) -> Agent:
     return agent
 
 
+async def send_system_message(
+    agent_id: str, text: str, response_policy: str = "discard", trigger: str = "",
+) -> bool:
+    """Send a system-level message to an agent (backend-initiated).
+
+    System messages notify agents of runtime state changes (secrets rotated,
+    instructions updated, teammates joined/left, config changed). They carry
+    response_policy metadata that controls feed visibility:
+        discard    — agent processes, no response expected, hidden from feed
+        silent_ack — same as discard for now (future: ack without feed entry)
+        visible    — shown in feed like a normal message
+
+    The message text is wrapped in <system-reminder> tags so Claude treats it
+    as context injection rather than a user prompt requiring a response.
+    """
+    op_log = log.bind(agent_id=agent_id, trigger=trigger)
+
+    try:
+        agent = await Agent.objects.aget(id=agent_id)
+    except Agent.DoesNotExist:
+        op_log.warning("agent_not_found")
+        return False
+
+    # Skip agents that aren't alive — system messages are informational,
+    # no point auto-restarting just to deliver a notification.
+    if agent.status not in (AgentStatus.RUNNING, AgentStatus.IDLE):
+        op_log.info("system_message_skipped", status=agent.status)
+        return False
+
+    # Build parts: text + metadata (metadata stripped before relay delivery)
+    system_meta = {"type": "_system_meta", "response_policy": response_policy, "trigger": trigger}
+    parts = [{"type": "text", "text": text}, system_meta]
+
+    msg_record = await Message.objects.acreate(
+        agent=agent,
+        message_id=f"sys_{uuid.uuid4().hex[:16]}",
+        session_id=agent.session_id or "",
+        role="system",
+        parts=parts,
+        turn_number=0,
+    )
+    await broadcast_stream_message(agent, msg_record)
+
+    # Wrap in <system-reminder> for relay delivery — Claude reads this as
+    # context, not a user prompt, so it typically won't produce a response.
+    relay_parts = [{"type": "text", "text": f"<system-reminder>\n{text}\n</system-reminder>"}]
+    input_msg = {
+        "type": "user",
+        "message": {"role": "user", "content": relay_parts},
+    }
+
+    agent = await _atomic_enqueue(agent_id, input_msg)
+    await broadcast_agent_update(agent)
+
+    op_log.info("system_message_sent", response_policy=response_policy)
+    return True
+
+
 async def send_message(agent_id: str, message: str, content: list | None = None) -> bool:
     """
     Enqueue a message for delivery to an agent's Claude Code session.

--- a/backend/agents/services/feed_transform.py
+++ b/backend/agents/services/feed_transform.py
@@ -41,6 +41,9 @@ def messages_to_feed(
 ) -> list[FeedItemType]:
     """Convert raw Messages + AgentEvents into sorted FeedItemType list."""
 
+    # Step 0: Filter out system messages with non-visible response_policy
+    messages = [m for m in messages if _should_include_in_feed(m)]
+
     # Step 1: Build tool_result index from user-role messages
     tool_results: dict[str, dict] = {}
     for msg in messages:
@@ -550,6 +553,20 @@ def _extract_plan_steps(text: str | None) -> list[str] | None:
             if step:
                 steps.append(step)
     return steps if steps else None
+
+
+def _should_include_in_feed(msg: "Message") -> bool:
+    """Check if a message should appear in the feed.
+
+    System messages (role="system") are excluded unless their response_policy
+    is "visible". All other messages pass through.
+    """
+    if msg.role != "system":
+        return True
+    meta = next((p for p in msg.parts if p.get("type") == "_system_meta"), None)
+    if not meta:
+        return True
+    return meta.get("response_policy") == "visible"
 
 
 def _parse_team_message(text: str) -> tuple[str | None, str | None]:

--- a/backend/agents/services/lifecycle.py
+++ b/backend/agents/services/lifecycle.py
@@ -100,6 +100,9 @@ async def create_agent(
     # Update team config in all existing agents so they can discover the new agent
     asyncio.create_task(update_team_configs(project))
 
+    # Notify existing agents about the new teammate
+    asyncio.create_task(_notify_teammates_joined(project, agent))
+
     return agent
 
 
@@ -460,6 +463,9 @@ async def remove_agent(agent_id: str) -> bool:
     project = await Project.objects.aget(id=project_id)
     asyncio.create_task(update_team_configs(project))
 
+    # Notify remaining agents about the departure
+    asyncio.create_task(_notify_teammates_left(project, agent_name))
+
     op_log.info("agent_removed")
     clear_agent_context()
     return True
@@ -632,3 +638,41 @@ async def resolve_agent_secrets(agent, op_log) -> dict[str, str] | None:
 
     op_log.info("secrets_resolved", count=len(merged), agent=agent.name)
     return merged
+
+
+async def _notify_teammates_joined(project, new_agent: Agent) -> None:
+    """Notify existing agents that a new teammate has joined."""
+    from agents.services.comms import send_system_message
+
+    agents = [
+        a async for a in Agent.objects.filter(
+            project=project,
+            status__in=[AgentStatus.RUNNING, AgentStatus.IDLE],
+        ).exclude(id=new_agent.id)
+    ]
+    for agent in agents:
+        await send_system_message(
+            str(agent.id),
+            f"Teammate {new_agent.name} ({new_agent.role}) has joined the team.",
+            response_policy="discard",
+            trigger="teammate_join",
+        )
+
+
+async def _notify_teammates_left(project, departed_name: str) -> None:
+    """Notify remaining agents that a teammate has left."""
+    from agents.services.comms import send_system_message
+
+    agents = [
+        a async for a in Agent.objects.filter(
+            project=project,
+            status__in=[AgentStatus.RUNNING, AgentStatus.IDLE],
+        )
+    ]
+    for agent in agents:
+        await send_system_message(
+            str(agent.id),
+            f"Teammate {departed_name} has left the team.",
+            response_policy="discard",
+            trigger="teammate_leave",
+        )


### PR DESCRIPTION
## Summary

Closes #54

- Add `send_system_message()` in `comms.py` — creates `Message(role="system")` with `_system_meta` metadata part, wraps text in `<system-reminder>` tags for relay delivery, enqueues via existing piggyback mechanism
- Add feed suppression filter in `feed_transform.py` — filters system messages by `response_policy` (`discard`/`silent_ack` hidden, `visible` shown)
- Wire five triggers: secret rotation, instruction update, teammate join, teammate leave, config change

## Design decisions

- **No new models or migrations** — reuses `Message.role` (CharField) with `"system"` value, metadata stored in `parts` JSONField via `_system_meta` convention (same pattern as existing `_broadcast`)
- **No relay changes** — system messages flow through existing `pending_input` piggyback, wrapped in `<system-reminder>` tags so Claude treats them as context injection
- **No new mutations/subscriptions** — system messages are backend-initiated only, broadcast through existing `message_received` subscription
- **`discard` and `silent_ack` are identical for now** — both use `<system-reminder>` wrapping; the distinction exists in metadata for future differentiation if needed

## Changes

| File | What |
|------|------|
| `backend/agents/services/comms.py` | `send_system_message()` — core function |
| `backend/agents/services/feed_transform.py` | `_should_include_in_feed()` filter at Step 0 |
| `backend/agents/graphql/mutations.py` | Triggers: secret rotation, instruction update, config change |
| `backend/agents/services/lifecycle.py` | Triggers: teammate join (`create_agent`), teammate leave (`remove_agent`) |

## Test plan

- [x] Django system checks pass
- [x] All imports resolve correctly
- [x] Unit tests: 6 feed suppression cases (user/assistant pass, discard filtered, silent_ack filtered, visible passes, no-meta passes)
- [ ] Integration: verify system message created with `role="system"` and `_system_meta` part
- [ ] Integration: verify `projectFeed`/`agentFeed` exclude discard/silent_ack system messages
- [ ] Integration: verify triggers fire on secret set, instruction update, agent create/remove, config update

🤖 Generated with [Claude Code](https://claude.com/claude-code)