### PR TITLE
Dashboard prototype: complete layout + feed + composer

### DIFF
--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -117,6 +117,13 @@
   --duration-slow: 200ms;
 }
 
+/* Force default cursor during resize drag — overrides all hover styles (Safari fix) */
+html.dragging-resize,
+html.dragging-resize * {
+  cursor: default !important;
+  user-select: none !important;
+}
+
 * {
   border-color: var(--color-border-default);
 }

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -2934,66 +2934,78 @@ function AgentCardRow({
           {viewMode === "settings" && <AgentSettingsPanel agent={agent} />}
         </div>
 
-        {/* Bottom toolbar: view icons | mini composer | todo */}
-        <div className="flex items-center gap-2 px-2.5 py-1.5 border-t border-border-subtle bg-surface-sunken/20">
-          {/* View mode icons */}
-          <div className="flex items-center gap-0.5 shrink-0">
-            {VIEW_MODES.map(({ id, icon: Icon, label }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setViewMode(id)}
-                className={cn(
-                  "p-1 rounded transition-colors",
-                  viewMode === id
-                    ? "bg-surface-raised text-default"
-                    : "text-muted/50 hover:text-secondary hover:bg-surface-raised/40",
+        {/* Bottom toolbar — swaps entirely when agent needs attention */}
+        {hasPendingItem ? (
+          <div className="border-t border-warning/20 bg-warning-subtle/10 px-3 py-2">
+            {TEAM_FEED.filter(
+              (item): item is Extract<TeamFeedItem, { type: "permission" } | { type: "plan" }> =>
+                (item.type === "permission" && item.agent === agent.name && item.permStatus === "pending") ||
+                (item.type === "plan" && item.agent === agent.name && item.planStatus === "pending"),
+            ).map((item, i) => (
+              <div key={i} className="flex items-center gap-2 min-w-0">
+                <Shield className="h-3.5 w-3.5 text-warning shrink-0" />
+                <span className="text-[11px] text-warning font-medium truncate flex-1 min-w-0">
+                  {item.type === "permission"
+                    ? item.command
+                    : item.title}
+                </span>
+                {item.type === "permission" ? (
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <button
+                      type="button"
+                      className="px-2.5 py-1 rounded-md text-[11px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                    >
+                      Allow
+                    </button>
+                    <button
+                      type="button"
+                      className="px-2.5 py-1 rounded-md text-[11px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                    >
+                      Deny
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <button
+                      type="button"
+                      className="px-2.5 py-1 rounded-md text-[11px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      type="button"
+                      className="px-2.5 py-1 rounded-md text-[11px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                    >
+                      Reject
+                    </button>
+                  </div>
                 )}
-                title={label}
-              >
-                <Icon className="h-3 w-3" />
-              </button>
+              </div>
             ))}
           </div>
-
-          {/* Mini composer — transforms when agent has pending attention item */}
-          {hasPendingItem ? (
-            <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded border border-warning/30 bg-warning-subtle/10 px-2 py-1">
-              <Clock className="h-3 w-3 text-warning shrink-0" />
-              <span className="text-[11px] text-warning font-medium truncate flex-1 min-w-0">Needs attention</span>
-              {TEAM_FEED.some(item => item.type === "permission" && item.agent === agent.name && item.permStatus === "pending") ? (
-                <div className="flex items-center gap-1 shrink-0">
-                  <button
-                    type="button"
-                    className="px-2 py-0.5 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-                  >
-                    Allow
-                  </button>
-                  <button
-                    type="button"
-                    className="px-2 py-0.5 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-                  >
-                    Deny
-                  </button>
-                </div>
-              ) : (
-                <div className="flex items-center gap-1 shrink-0">
-                  <button
-                    type="button"
-                    className="px-2 py-0.5 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-                  >
-                    Approve
-                  </button>
-                  <button
-                    type="button"
-                    className="px-2 py-0.5 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-                  >
-                    Reject
-                  </button>
-                </div>
-              )}
+        ) : (
+          <div className="flex items-center gap-2 px-2.5 py-1.5 border-t border-border-subtle bg-surface-sunken/20">
+            {/* View mode icons */}
+            <div className="flex items-center gap-0.5 shrink-0">
+              {VIEW_MODES.map(({ id, icon: Icon, label }) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setViewMode(id)}
+                  className={cn(
+                    "p-1 rounded transition-colors",
+                    viewMode === id
+                      ? "bg-surface-raised text-default"
+                      : "text-muted/50 hover:text-secondary hover:bg-surface-raised/40",
+                  )}
+                  title={label}
+                >
+                  <Icon className="h-3 w-3" />
+                </button>
+              ))}
             </div>
-          ) : (
+
+            {/* Mini composer */}
             <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded border border-border-default bg-surface-sunken/40 px-2 py-1">
               <span className="text-[9px] text-accent font-mono shrink-0">@{agent.name}</span>
               <input
@@ -3008,18 +3020,18 @@ function AgentCardRow({
                 <ArrowUp className="h-2.5 w-2.5" strokeWidth={2.5} />
               </button>
             </div>
-          )}
 
-          {/* Todo progress */}
-          {agent.todoProgress && (
-            <span className="flex items-center gap-1 shrink-0">
-              <CheckSquare className="h-3 w-3 text-muted/50" />
-              <span className="text-[9px] font-mono text-muted tabular-nums">
-                {agent.todoProgress.done}/{agent.todoProgress.total}
+            {/* Todo progress */}
+            {agent.todoProgress && (
+              <span className="flex items-center gap-1 shrink-0">
+                <CheckSquare className="h-3 w-3 text-muted/50" />
+                <span className="text-[9px] font-mono text-muted tabular-nums">
+                  {agent.todoProgress.done}/{agent.todoProgress.total}
+                </span>
               </span>
-            </span>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </Collapsible>
     </div>
   )

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -2348,12 +2348,14 @@ function RecipientSearchBox({
   recipients,
   onAddRecipient,
   onRemoveRecipient,
+  onSuggestionsChange,
 }: {
   agents: FakeAgent[]
   allTags: string[]
   recipients: RecipientEntry[]
   onAddRecipient: (entry: RecipientEntry) => void
   onRemoveRecipient: (index: number) => void
+  onSuggestionsChange?: (suggestions: RecipientEntry[]) => void
 }) {
   const [inputValue, setInputValue] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
@@ -2464,8 +2466,12 @@ function RecipientSearchBox({
     return []
   }, [inputValue, agents, allTags, recipients])
 
+  useEffect(() => {
+    onSuggestionsChange?.(suggestions)
+  }, [suggestions, onSuggestionsChange])
+
   return (
-    <div className="flex flex-col min-w-0 flex-1">
+    <div className="min-w-0 flex-1">
       {/* Dark search input */}
       <div className="relative flex items-center min-w-0 rounded-md bg-surface-sunken/50 px-2 py-1">
         <span
@@ -2493,22 +2499,6 @@ function RecipientSearchBox({
           </span>
         )}
       </div>
-
-      {/* Autocomplete suggestions */}
-      {suggestions.length > 0 && (
-        <div className="flex items-center gap-1 mt-1 overflow-x-auto no-scrollbar">
-          {suggestions.map(s => (
-            <button
-              key={recipientKey(s)}
-              type="button"
-              onClick={() => { onAddRecipient(s); setInputValue("") }}
-              className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-mono bg-surface-sunken text-secondary hover:bg-surface-sunken/80 hover:text-default transition-colors"
-            >
-              {recipientLabel(s)}
-            </button>
-          ))}
-        </div>
-      )}
     </div>
   )
 }
@@ -2530,6 +2520,12 @@ function ComposerBar({
   onAddRecipient: (entry: RecipientEntry) => void
   onRemoveRecipient: (index: number) => void
 }) {
+  const [suggestions, setSuggestions] = useState<RecipientEntry[]>([])
+
+  const handleSuggestionsChange = useCallback((s: RecipientEntry[]) => {
+    setSuggestions(s)
+  }, [])
+
   const placeholderName = recipients.length === 0
     ? "your team"
     : recipients.length === 1
@@ -2540,41 +2536,25 @@ function ComposerBar({
   const visiblePills = recipients.slice(0, MAX_VISIBLE_PILLS)
   const overflowCount = Math.max(0, recipients.length - MAX_VISIBLE_PILLS)
 
-  // Hide "To:" line when it's just the default @team-lead
+  // Dont show committed pills when just the default @team-lead
   const isDefault = recipients.length === 1 && recipients[0].type === "agent" && recipients[0].value === "team-lead"
+
+  const hasPillContent = (!isDefault && recipients.length > 0) || suggestions.length > 0
 
   return (
     <div className="px-6 pb-4 pt-2 max-w-3xl mx-auto w-full shrink-0">
-      {/* To: pills row — hidden when just the default recipient */}
-      {!isDefault && <div className="flex items-center gap-1.5 px-1 pb-1.5 min-w-0 overflow-x-auto no-scrollbar">
-        <span className="text-[10px] text-muted/50 font-medium shrink-0">To:</span>
-        {visiblePills.map((r, i) => (
-          <span
-            key={recipientKey(r)}
-            className="inline-flex items-center gap-1 pl-2 pr-1.5 py-0.5 rounded-full bg-surface-sunken text-[10px] font-mono text-secondary shrink-0"
-          >
-            {recipientLabel(r)}
-            <button
-              type="button"
-              onClick={() => onRemoveRecipient(i)}
-              className="text-muted/40 hover:text-muted transition-colors"
-            >
-              <X className="h-2.5 w-2.5" />
-            </button>
-          </span>
-        ))}
-        {overflowCount > 0 && (
-          <span className="text-[10px] text-muted font-mono shrink-0">+{overflowCount}</span>
-        )}
-      </div>}
-
       {/* Composer box */}
       <div className="relative rounded-2xl border-[0.5px] border-border-default bg-surface-raised/60 focus-within:bg-surface-raised focus-within:border-border-default">
-        {/* Text input */}
+        {/* Text input — auto-grows up to ~6 rows then scrolls */}
         <textarea
           placeholder={placeholder}
           rows={1}
-          className="w-full bg-transparent border-none outline-none resize-none px-4 pt-4 pb-2 text-sm text-default placeholder:text-muted min-h-[52px] max-h-[40vh]"
+          onInput={(e) => {
+            const el = e.currentTarget
+            el.style.height = "auto"
+            el.style.height = `${el.scrollHeight}px`
+          }}
+          className="w-full bg-transparent border-none outline-none resize-none px-4 pt-4 pb-2 text-sm text-default placeholder:text-muted min-h-[52px] max-h-[200px] overflow-y-auto"
         />
 
         {/* Toolbar row */}
@@ -2594,6 +2574,7 @@ function ComposerBar({
               recipients={recipients}
               onAddRecipient={onAddRecipient}
               onRemoveRecipient={onRemoveRecipient}
+              onSuggestionsChange={handleSuggestionsChange}
             />
           </div>
 
@@ -2608,6 +2589,41 @@ function ComposerBar({
             </button>
           </div>
         </div>
+      </div>
+
+      {/* Pills row — underneath the composer box */}
+      <div className="flex items-center gap-1.5 px-1 pt-2 min-w-0 overflow-x-auto no-scrollbar min-h-[28px]">
+        {/* Committed pills */}
+        {!isDefault && visiblePills.map((r, i) => (
+          <span
+            key={recipientKey(r)}
+            className="inline-flex items-center gap-1 pl-2 pr-1.5 py-0.5 rounded-full bg-surface-sunken text-[10px] font-mono text-secondary shrink-0"
+          >
+            {recipientLabel(r)}
+            <button
+              type="button"
+              onClick={() => onRemoveRecipient(i)}
+              className="text-muted/40 hover:text-muted transition-colors"
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </span>
+        ))}
+        {!isDefault && overflowCount > 0 && (
+          <span className="text-[10px] text-muted font-mono shrink-0">+{overflowCount}</span>
+        )}
+        {/* Autocomplete suggestions inline */}
+        {suggestions.map(s => (
+          <button
+            key={`sug-${recipientKey(s)}`}
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onAddRecipient(s)}
+            className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-mono bg-surface-sunken/50 text-muted hover:bg-surface-sunken hover:text-secondary transition-colors border border-border-subtle/50"
+          >
+            {recipientLabel(s)}
+          </button>
+        ))}
       </div>
     </div>
   )
@@ -4303,12 +4319,16 @@ function ResizeHandle({
       onPointerCancel={onPointerCancel}
       onDoubleClick={onReset}
       className={cn(
-        "absolute top-0 bottom-0 w-1 z-(--z-dropdown) cursor-col-resize group/resize",
-        side === "left" ? "left-0" : "right-0",
+        "absolute top-0 bottom-0 w-3 z-(--z-dropdown) cursor-col-resize group/resize",
+        side === "left" ? "-left-1.5" : "-right-1.5",
       )}
     >
-      {/* Visual indicator on hover/drag */}
-      <div className="absolute inset-y-0 left-0 w-px bg-transparent group-hover/resize:bg-accent/50 group-active/resize:bg-accent transition-colors" />
+      {/* Full-height border highlight on hover/drag */}
+      <div className={cn(
+        "absolute inset-y-0 w-0.5 transition-colors",
+        "bg-transparent group-hover/resize:bg-accent/50 group-active/resize:bg-accent",
+        side === "left" ? "left-1.5" : "right-1.5",
+      )} />
     </div>
   )
 }
@@ -4390,8 +4410,10 @@ export default function PrototypePage() {
   const pendingCount = useMemo(() => getAllPendingItems(feedItems).length, [feedItems])
 
   // Expand recipients to flat set of agent names (tags resolve to their agents)
-  // @all = no filter (empty set means all pass through)
+  // Default (@team-lead) and @all = no filter (empty set means all pass through)
+  const isDefaultRecipient = recipients.length === 1 && recipients[0].type === "agent" && recipients[0].value === "team-lead"
   const effectiveAgentFilter = useMemo(() => {
+    if (isDefaultRecipient) return new Set<string>()
     if (recipients.some(r => r.type === "all")) return new Set<string>()
     if (recipients.length === 0) return new Set<string>()
     const names = new Set<string>()
@@ -4400,7 +4422,7 @@ export default function PrototypePage() {
       else if (r.type === "tag") for (const a of agents) { if (a.tags.includes(r.value)) names.add(a.name) }
     }
     return names
-  }, [recipients, agents])
+  }, [recipients, agents, isDefaultRecipient])
 
   const singleFilteredAgent = useMemo(() =>
     effectiveAgentFilter.size === 1 ? Array.from(effectiveAgentFilter)[0] : null

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -25,6 +25,8 @@ import {
   ChevronsUpDown,
   ChevronsDownUp,
   Settings,
+  Monitor,
+  List,
 } from "lucide-react"
 import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -1251,8 +1253,8 @@ function FleetHealthPills({
 
 function AgentLeftPanel({
   agents,
-  cardStates,
-  onSelectAgent,
+  expandedIds,
+  onToggleAgent,
   onToggleExpandAll,
   onOpenSecrets,
   isOpen,
@@ -1262,8 +1264,8 @@ function AgentLeftPanel({
   onResetWidth,
 }: {
   agents: FakeAgent[]
-  cardStates: Record<string, CardState>
-  onSelectAgent: (id: string) => void
+  expandedIds: Set<string>
+  onToggleAgent: (id: string) => void
   onToggleExpandAll: () => void
   onOpenSecrets: () => void
   isOpen: boolean
@@ -1303,7 +1305,7 @@ function AgentLeftPanel({
         <div className="flex-1 flex flex-col items-center gap-1.5 py-2 overflow-y-auto">
           {agents.map((agent) => {
             const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
-            const isSelected = (cardStates[agent.id] ?? "collapsed") !== "collapsed"
+            const isSelected = expandedIds.has(agent.id)
             const isRunning = agent.status === "running"
             const isStopped = agent.status === "stopped"
 
@@ -1312,7 +1314,7 @@ function AgentLeftPanel({
                 key={agent.id}
                 type="button"
                 onClick={() => {
-                  onSelectAgent(agent.id)
+                  if (!expandedIds.has(agent.id)) onToggleAgent(agent.id)
                   onToggleOpen()
                 }}
                 className={cn(
@@ -1412,7 +1414,7 @@ function AgentLeftPanel({
           className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
           title="Cycle card states"
         >
-          {Object.values(cardStates).some((s) => s === "expanded") ? (
+          {expandedIds.size > 0 ? (
             <ChevronsDownUp className="h-3.5 w-3.5" />
           ) : (
             <ChevronsUpDown className="h-3.5 w-3.5" />
@@ -1435,8 +1437,8 @@ function AgentLeftPanel({
             <AgentCardRow
               key={agent.id}
               agent={agent}
-              cardState={cardStates[agent.id] ?? "collapsed"}
-              onSelect={() => onSelectAgent(agent.id)}
+              isOpen={expandedIds.has(agent.id)}
+              onToggle={() => onToggleAgent(agent.id)}
             />
           ))}
         </div>
@@ -1756,36 +1758,37 @@ function AgentSettingsPanel({ agent }: { agent: FakeAgent }) {
   )
 }
 
-type CardState = "collapsed" | "preview" | "expanded"
+type ViewMode = "terminal" | "feed" | "settings"
 
 /**
- * Agent card — three states:
+ * Agent card — two states:
  *
  * COLLAPSED — compact single row:
  *   avatar | name | status dot | live action | cost · time | chevron
  *
- * PREVIEW — VNC glance view (no tabs, no detail feed):
- *   collapsed header + VNC + stats row + live status bar
- *
- * EXPANDED — full detail:
- *   preview + Activity/Settings tabs + detail feed + mini composer
+ * OPEN — content area + bottom toolbar:
+ *   header row → content (VNC / feed / settings) → toolbar (view icons + composer + todo)
  */
 function AgentCardRow({
   agent,
-  cardState,
-  onSelect,
+  isOpen,
+  onToggle,
 }: {
   agent: FakeAgent
-  cardState: CardState
-  onSelect: () => void
+  isOpen: boolean
+  onToggle: () => void
 }) {
   const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
   const isRunning = agent.status === "running"
   const isError = agent.status === "error"
   const isStopped = agent.status === "stopped"
-  const isOpen = cardState !== "collapsed"
-  const isFullDetail = cardState === "expanded"
-  const [detailTab, setDetailTab] = useState<"activity" | "settings">("activity")
+  const [viewMode, setViewMode] = useState<ViewMode>("terminal")
+
+  const VIEW_MODES: { id: ViewMode; icon: typeof Monitor; label: string }[] = [
+    { id: "terminal", icon: Monitor, label: "Screen" },
+    { id: "feed", icon: List, label: "Feed" },
+    { id: "settings", icon: Settings, label: "Settings" },
+  ]
 
   return (
     <div
@@ -1800,10 +1803,10 @@ function AgentCardRow({
             ),
       )}
     >
-      {/* Collapsed row — always visible, click to cycle state */}
+      {/* Header row — always visible, click to toggle */}
       <button
         type="button"
-        onClick={onSelect}
+        onClick={onToggle}
         className="w-full text-left px-2.5 py-2"
       >
         <div className="flex items-center gap-2 min-w-0">
@@ -1843,73 +1846,69 @@ function AgentCardRow({
             size={14}
             className={cn(
               "shrink-0 text-muted transition-transform duration-(--duration-normal)",
-              cardState === "preview" && "rotate-45",
-              cardState === "expanded" && "rotate-90",
+              isOpen && "rotate-90",
             )}
           />
         </div>
       </button>
 
-      {/* Preview + expanded content — animated reveal */}
+      {/* Open content — animated reveal */}
       <Collapsible open={isOpen}>
-        {/* VNC full width */}
+        {/* Content area — swaps based on view mode */}
         <div className="px-3 pb-2">
-          <VncThumbnail agent={agent} />
+          {viewMode === "terminal" && <VncThumbnail agent={agent} />}
+          {viewMode === "feed" && <AgentDetailFeed agent={agent} />}
+          {viewMode === "settings" && <AgentSettingsPanel agent={agent} />}
         </div>
 
-        {/* Stats row */}
-        <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap px-3 pb-2">
-          <span className="inline-flex items-center gap-0.5">
-            <DollarSign className="h-2.5 w-2.5" />
-            {formatCost(agent.cost)}
-          </span>
-          <span className="inline-flex items-center gap-0.5">
-            <Clock className="h-2.5 w-2.5" />
-            {agent.duration}
-          </span>
-          <span className="text-muted/50">&middot;</span>
-          <span>{agent.model}</span>
-          <span className="text-muted/50">&middot;</span>
-          <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
+        {/* Bottom toolbar: view icons | mini composer | todo */}
+        <div className="flex items-center gap-2 px-2.5 py-1.5 border-t border-border-subtle bg-surface-sunken/20">
+          {/* View mode icons */}
+          <div className="flex items-center gap-0.5 shrink-0">
+            {VIEW_MODES.map(({ id, icon: Icon, label }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setViewMode(id)}
+                className={cn(
+                  "p-1 rounded transition-colors",
+                  viewMode === id
+                    ? "bg-surface-raised text-default"
+                    : "text-muted/50 hover:text-secondary hover:bg-surface-raised/40",
+                )}
+                title={label}
+              >
+                <Icon className="h-3 w-3" />
+              </button>
+            ))}
+          </div>
+
+          {/* Mini composer */}
+          <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded border border-border-default bg-surface-sunken/40 px-2 py-1">
+            <span className="text-[9px] text-accent font-mono shrink-0">@{agent.name}</span>
+            <input
+              type="text"
+              placeholder="Message..."
+              className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
+            />
+            <button
+              type="button"
+              className="flex items-center justify-center h-4 w-4 rounded-full bg-surface text-muted shrink-0"
+            >
+              <ArrowUp className="h-2.5 w-2.5" strokeWidth={2.5} />
+            </button>
+          </div>
+
+          {/* Todo progress */}
+          {agent.todoProgress && (
+            <span className="flex items-center gap-1 shrink-0">
+              <CheckSquare className="h-3 w-3 text-muted/50" />
+              <span className="text-[9px] font-mono text-muted tabular-nums">
+                {agent.todoProgress.done}/{agent.todoProgress.total}
+              </span>
+            </span>
+          )}
         </div>
-
-        {/* Live status bar */}
-        {isRunning && <LiveStatusBar agent={agent} />}
-      </Collapsible>
-
-      {/* Full detail — second collapsible for tabs + feed */}
-      <Collapsible open={isFullDetail}>
-        {/* Inline tab bar — Activity | Settings */}
-        <div className="flex items-center gap-1 px-3 py-1 border-t border-border-subtle bg-surface-sunken/20">
-          <button
-            type="button"
-            onClick={() => setDetailTab("activity")}
-            className={cn(
-              "px-2 py-1 rounded text-[11px] font-medium transition-colors",
-              detailTab === "activity" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
-            )}
-          >
-            Activity
-          </button>
-          <button
-            type="button"
-            onClick={() => setDetailTab("settings")}
-            className={cn(
-              "px-2 py-1 rounded text-[11px] font-medium transition-colors",
-              detailTab === "settings" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
-            )}
-          >
-            <Settings className="h-3 w-3 inline mr-1" />
-            Settings
-          </button>
-        </div>
-
-        {/* Tab content */}
-        {detailTab === "activity" ? (
-          <AgentDetailFeed agent={agent} />
-        ) : (
-          <AgentSettingsPanel agent={agent} />
-        )}
       </Collapsible>
     </div>
   )
@@ -2051,12 +2050,12 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
 
 function AgentCardsPanel({
   agents,
-  cardStates,
-  onSelectAgent,
+  expandedIds,
+  onToggleAgent,
 }: {
   agents: FakeAgent[]
-  cardStates: Record<string, CardState>
-  onSelectAgent: (id: string) => void
+  expandedIds: Set<string>
+  onToggleAgent: (id: string) => void
 }) {
   return (
     <ScrollArea className="h-full overflow-y-auto">
@@ -2065,8 +2064,8 @@ function AgentCardsPanel({
           <AgentCardRow
             key={agent.id}
             agent={agent}
-            cardState={cardStates[agent.id] ?? "collapsed"}
-            onSelect={() => onSelectAgent(agent.id)}
+            isOpen={expandedIds.has(agent.id)}
+            onToggle={() => onToggleAgent(agent.id)}
           />
         ))}
       </div>
@@ -2217,7 +2216,7 @@ function ResizeHandle({
 
 export default function PrototypePage() {
   const bp = useBreakpoint()
-  const [cardStates, setCardStates] = useState<Record<string, CardState>>({ "1": "preview" })
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(["1"]))
   const [mainTab, setMainTab] = useState<"chat" | "agents">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
   const [agentPanelOpen, setAgentPanelOpen] = useState(true)
@@ -2230,32 +2229,20 @@ export default function PrototypePage() {
     else if (bp !== "mobile") setAgentPanelOpen(true)
   }, [bp])
 
-  const CARD_CYCLE: Record<CardState, CardState> = { collapsed: "preview", preview: "expanded", expanded: "collapsed" }
-
-  const handleSelectAgentCard = useCallback((id: string) => {
-    setCardStates((prev) => {
-      const current = prev[id] ?? "collapsed"
-      const next = CARD_CYCLE[current]
-      return { ...prev, [id]: next }
+  const handleToggleAgent = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
     })
   }, [])
 
   const handleToggleExpandAll = useCallback(() => {
-    setCardStates((prev) => {
-      const states = AGENTS.map((a) => prev[a.id] ?? "collapsed")
-      const allExpanded = states.every((s) => s === "expanded")
-      const allPreview = states.every((s) => s === "preview")
-      const allCollapsed = states.every((s) => s === "collapsed")
-
-      let target: CardState
-      if (allCollapsed) target = "preview"
-      else if (allPreview) target = "expanded"
-      else if (allExpanded) target = "collapsed"
-      else target = "preview" // mixed → normalize to preview
-
-      const next: Record<string, CardState> = {}
-      for (const a of AGENTS) next[a.id] = target
-      return next
+    setExpandedIds((prev) => {
+      const allOpen = AGENTS.every((a) => prev.has(a.id))
+      if (allOpen) return new Set()
+      return new Set(AGENTS.map((a) => a.id))
     })
   }, [])
 
@@ -2295,8 +2282,8 @@ export default function PrototypePage() {
       {showLeftPanel && (
         <AgentLeftPanel
           agents={AGENTS}
-          cardStates={cardStates}
-          onSelectAgent={handleSelectAgentCard}
+          expandedIds={expandedIds}
+          onToggleAgent={handleToggleAgent}
           onToggleExpandAll={handleToggleExpandAll}
           onOpenSecrets={() => setSecretsOpen(true)}
           isOpen={agentPanelOpen}
@@ -2330,8 +2317,8 @@ export default function PrototypePage() {
           <div className="flex-1 min-w-0 bg-surface">
             <AgentCardsPanel
               agents={AGENTS}
-              cardStates={cardStates}
-              onSelectAgent={handleSelectAgentCard}
+              expandedIds={expandedIds}
+              onToggleAgent={handleToggleAgent}
             />
           </div>
         )}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1,0 +1,1868 @@
+"use client"
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import {
+  PanelLeftClose,
+  PanelLeftOpen,
+  ArrowUp,
+  Users,
+  MessageSquare,
+  ChevronRight,
+  Check,
+  X,
+  AlertCircle,
+  Plus,
+  Code,
+  Terminal,
+  Clock,
+  DollarSign,
+  RotateCcw,
+  CheckSquare,
+  KeyRound,
+  Eye,
+  EyeOff,
+  Trash2,
+  AlertTriangle,
+  RefreshCw,
+} from "lucide-react"
+import { cn, agentHue, formatCost } from "@/lib/utils"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Collapsible } from "@/components/ui/collapsible"
+import { MarkdownRenderer } from "@/components/shared/markdown-renderer"
+
+/* ================================================================== */
+/*  FAKE DATA                                                          */
+/* ================================================================== */
+
+type FakeAgent = {
+  id: string
+  name: string
+  status: "running" | "error" | "idle" | "stopped" | "waiting"
+  task: string
+  cost: number
+  duration: string
+  model: string
+  turns: number
+  lastOutput: string
+  phase?: string
+}
+
+const AGENTS: FakeAgent[] = [
+  {
+    id: "1",
+    name: "backend",
+    status: "running",
+    task: "Editing auth.ts — fixing JWT validation",
+    cost: 0.12,
+    duration: "3m 22s",
+    model: "Opus 4.6",
+    turns: 8,
+    lastOutput: "Applied fix to validateToken()...",
+    phase: "Editing",
+  },
+  {
+    id: "2",
+    name: "frontend",
+    status: "running",
+    task: "Reading component styles",
+    cost: 0.08,
+    duration: "1m 45s",
+    model: "Sonnet 4.6",
+    turns: 4,
+    lastOutput: "Scanning tailwind classes in Button...",
+    phase: "Reading",
+  },
+  {
+    id: "3",
+    name: "qa",
+    status: "error",
+    task: "npm test failed",
+    cost: 0.05,
+    duration: "2m 10s",
+    model: "Sonnet 4.6",
+    turns: 3,
+    lastOutput: "FAIL src/auth.test.ts\nExpected 200, received 401",
+  },
+  {
+    id: "4",
+    name: "devops",
+    status: "idle",
+    task: "Waiting for backend",
+    cost: 0.03,
+    duration: "5m 00s",
+    model: "Haiku 4.5",
+    turns: 1,
+    lastOutput: "Standing by...",
+  },
+  {
+    id: "5",
+    name: "docs",
+    status: "stopped",
+    task: "Completed README update",
+    cost: 0.02,
+    duration: "1m 30s",
+    model: "Haiku 4.5",
+    turns: 2,
+    lastOutput: "Updated API reference section",
+  },
+]
+
+type FakeSecret = {
+  id: string
+  key: string
+  value: string
+  addedAgo: string
+}
+
+const SECRETS: FakeSecret[] = [
+  { id: "s1", key: "GITHUB_TOKEN", value: "ghp_a1b2c3d4e5f6g7h8i9j0", addedAgo: "2d ago" },
+  { id: "s2", key: "ANTHROPIC_API_KEY", value: "sk-ant-api03-xxxxxxxxxxxx", addedAgo: "5d ago" },
+  { id: "s3", key: "AWS_ACCESS_KEY_ID", value: "AKIAIOSFODNN7EXAMPLE", addedAgo: "1w ago" },
+  { id: "s4", key: "OPENAI_API_KEY", value: "sk-proj-xxxxxxxxxxxxxxxx", addedAgo: "1w ago" },
+]
+
+const FAKE_MARKDOWN = `I've analyzed the JWT validation issue. The problem is in \`validateToken()\` — the expiry comparison uses **seconds** but \`Date.now()\` returns **milliseconds**.
+
+Here's the fix:
+
+\`\`\`typescript
+function validateToken(token: string): boolean {
+  const decoded = jwt.decode(token)
+  const now = Math.floor(Date.now() / 1000) // Convert to seconds
+  return decoded.exp > now
+}
+\`\`\`
+
+The changes needed:
+- Convert \`Date.now()\` to seconds before comparison
+- Add a 30-second clock skew tolerance
+- Log validation failures for debugging
+
+| Before | After |
+|--------|-------|
+| \`Date.now()\` (ms) | \`Math.floor(Date.now() / 1000)\` (s) |
+| No skew tolerance | 30s tolerance |
+| Silent failures | Structured logging |`
+
+/* ================================================================== */
+/*  STATUS CONFIG                                                      */
+/* ================================================================== */
+
+const STATUS_CONFIG: Record<
+  string,
+  { dot: string; label: string; glow?: string; text?: string }
+> = {
+  running: { dot: "bg-success", label: "Running", glow: "text-success", text: "text-success" },
+  idle: { dot: "bg-info", label: "Idle", text: "text-info" },
+  waiting: { dot: "bg-warning", label: "Waiting", text: "text-warning" },
+  error: { dot: "bg-danger", label: "Error", text: "text-danger" },
+  stopped: { dot: "bg-muted/50", label: "Stopped", text: "text-muted" },
+}
+
+const PILL_CONFIG = [
+  { key: "error" as const, dot: "bg-danger", text: "text-danger" },
+  { key: "running" as const, dot: "bg-success", text: "text-success", animate: true },
+  { key: "idle" as const, dot: "bg-info", text: "text-muted" },
+  { key: "stopped" as const, dot: "bg-muted/40", text: "text-muted/50" },
+]
+
+/* ================================================================== */
+/*  BREAKPOINT HOOK                                                    */
+/* ================================================================== */
+
+type Breakpoint = "mobile" | "S" | "M" | "L" | "XL"
+
+function useBreakpoint(): Breakpoint {
+  const [bp, setBp] = useState<Breakpoint>("XL")
+
+  useEffect(() => {
+    function calc() {
+      const w = window.innerWidth
+      if (w < 1024) setBp("mobile")
+      else if (w < 1280) setBp("S")
+      else if (w < 1440) setBp("M")
+      else if (w < 1920) setBp("L")
+      else setBp("XL")
+    }
+    calc()
+    window.addEventListener("resize", calc)
+    return () => window.removeEventListener("resize", calc)
+  }, [])
+
+  return bp
+}
+
+/* ================================================================== */
+/*  AGENT AVATAR                                                       */
+/* ================================================================== */
+
+function AgentAvatar({
+  name,
+  size = "md",
+  stopped = false,
+}: {
+  name: string
+  size?: "sm" | "md" | "lg"
+  stopped?: boolean
+}) {
+  const hue = agentHue(name)
+  const dims = size === "sm" ? "h-5 w-5" : size === "lg" ? "h-8 w-8" : "h-6 w-6"
+  const textSize = size === "sm" ? "text-[9px]" : size === "lg" ? "text-[12px]" : "text-[10px]"
+  const radius = size === "sm" ? "rounded" : "rounded-md"
+
+  return (
+    <div
+      className={cn(dims, radius, "flex items-center justify-center font-bold shrink-0", textSize)}
+      style={{
+        backgroundColor: `hsl(${hue} ${stopped ? "25%" : "40%"} ${stopped ? "18%" : "22%"})`,
+        color: `hsl(${hue} ${stopped ? "30%" : "55%"} ${stopped ? "45%" : "68%"})`,
+      }}
+    >
+      {name.charAt(0).toUpperCase()}
+    </div>
+  )
+}
+
+/** Round avatar for chat feed (matches assistant-message.tsx) */
+function ChatAvatar({ name }: { name: string }) {
+  const hue = agentHue(name)
+  return (
+    <div
+      className="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold text-on-emphasis mt-1"
+      style={{
+        backgroundColor: `hsl(${hue} var(--color-avatar-saturation) var(--color-avatar-lightness))`,
+      }}
+    >
+      {name.charAt(0).toUpperCase()}
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  FEED CONTENT COMPONENTS                                            */
+/* ================================================================== */
+
+/** 1. User message — right-aligned bubble */
+function UserMessage({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end py-1">
+      <div className="max-w-[80%]">
+        <div className="bg-accent/15 border border-accent/20 rounded px-3 py-1.5">
+          <p className="text-default text-sm whitespace-pre-wrap leading-relaxed">
+            {text}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 2. Assistant message with markdown — left-aligned with avatar */
+function AssistantMessage({
+  agent,
+  content,
+  showAvatar = true,
+}: {
+  agent: string
+  content: string
+  showAvatar?: boolean
+}) {
+  return (
+    <div className="group/msg flex gap-2 min-w-0 relative">
+      {showAvatar ? (
+        <ChatAvatar name={agent} />
+      ) : (
+        <div className="shrink-0 w-6" />
+      )}
+      <div className="min-w-0 flex-1">
+        {showAvatar && (
+          <div className="text-[11px] text-muted font-mono mb-0.5">
+            {agent}
+          </div>
+        )}
+        <MarkdownRenderer
+          content={content}
+          className="text-sm text-default"
+        />
+      </div>
+    </div>
+  )
+}
+
+/** 3. Tool call group — single tool, collapsible */
+function SingleToolRow({
+  toolName,
+  summary,
+}: {
+  toolName: string
+  summary: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="ml-8">
+      <div className="border-l-2 rounded-r border-l-muted/40">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-2 w-full text-left px-2.5 py-1 cursor-pointer hover:bg-surface-sunken/40 transition-colors"
+        >
+          <ChevronRight
+            size={12}
+            className={cn(
+              "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+              expanded && "rotate-90",
+            )}
+          />
+          <span className="text-xs font-medium shrink-0 text-info">
+            {toolName}
+          </span>
+          <span className="text-xs text-muted font-mono truncate min-w-0">
+            {summary}
+          </span>
+        </button>
+        <Collapsible open={expanded}>
+          <div className="px-3 py-2 ml-4">
+            <div className="rounded bg-surface-sunken/60 p-2">
+              <p className="font-mono text-xs text-secondary whitespace-pre-wrap">
+                {toolName === "Read"
+                  ? "Reading file contents... (47 lines)"
+                  : toolName === "Edit"
+                    ? 'old_string: "Date.now()"\nnew_string: "Math.floor(Date.now() / 1000)"'
+                    : toolName === "Bash"
+                      ? "$ npm run lint\n✓ No errors found"
+                      : "Operation completed successfully"}
+              </p>
+            </div>
+          </div>
+        </Collapsible>
+      </div>
+    </div>
+  )
+}
+
+/** 3b. Multi-tool group — collapsible group header */
+function MultiToolGroup({
+  tools,
+}: {
+  tools: { name: string; summary: string }[]
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  const uniqueNames = tools
+    .map((t) => t.name)
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .join(", ")
+
+  return (
+    <div className="ml-8">
+      <div className="border-l-2 rounded-r border-l-muted/40">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-2 w-full text-left px-2.5 py-1 cursor-pointer hover:bg-surface-sunken/40 transition-colors"
+        >
+          <ChevronRight
+            size={12}
+            className={cn(
+              "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+              expanded && "rotate-90",
+            )}
+          />
+          <span className="text-xs text-secondary">
+            {tools.length} tool uses
+          </span>
+          <span className="text-[11px] text-muted font-mono truncate min-w-0">
+            {uniqueNames}
+          </span>
+        </button>
+        <Collapsible open={expanded}>
+          <div className="ml-2 space-y-px">
+            {tools.map((tool, i) => (
+              <ToolRow key={i} toolName={tool.name} summary={tool.summary} />
+            ))}
+          </div>
+        </Collapsible>
+      </div>
+    </div>
+  )
+}
+
+function ToolRow({ toolName, summary }: { toolName: string; summary: string }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 w-full text-left px-2.5 py-0.5 cursor-pointer hover:bg-surface-sunken/40 transition-colors"
+      >
+        <ChevronRight
+          size={10}
+          className={cn(
+            "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="text-[11px] font-medium shrink-0 text-info">
+          {toolName}
+        </span>
+        <span className="text-[11px] text-muted font-mono truncate min-w-0">
+          {summary}
+        </span>
+      </button>
+      <Collapsible open={expanded}>
+        <div className="px-3 py-1.5 ml-4">
+          <div className="rounded bg-surface-sunken/60 p-2">
+            <p className="font-mono text-[11px] text-secondary">
+              Tool output for {toolName}
+            </p>
+          </div>
+        </div>
+      </Collapsible>
+    </div>
+  )
+}
+
+/** 4. Result pill — compact inline status */
+function ResultPill({
+  isError = false,
+  cost,
+  duration,
+  turns,
+  model,
+}: {
+  isError?: boolean
+  cost: number
+  duration: string
+  turns: number
+  model: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="ml-8">
+      <button
+        type="button"
+        className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-mono cursor-pointer hover:bg-surface-sunken/40 transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {isError ? (
+          <X size={12} className="shrink-0 text-danger" strokeWidth={2.5} />
+        ) : (
+          <Check size={12} className="shrink-0 text-success" strokeWidth={2.5} />
+        )}
+        {cost > 0 && (
+          <span className="text-secondary">{formatCost(cost)}</span>
+        )}
+        <span className="text-muted/50">&middot;</span>
+        <span className="text-muted">{duration}</span>
+        <ChevronRight
+          size={10}
+          className={cn(
+            "shrink-0 text-muted/60 transition-transform duration-(--duration-normal) ml-0.5",
+            expanded && "rotate-90",
+          )}
+        />
+      </button>
+      <Collapsible open={expanded}>
+        <div className="ml-2 mt-0.5 space-y-0.5">
+          <div className="text-[10px] font-mono text-muted">
+            {turns} turn{turns !== 1 ? "s" : ""}
+          </div>
+          <div className="flex items-center gap-2 text-[10px] font-mono">
+            <span className="text-secondary truncate min-w-0 max-w-[140px]">
+              {model}
+            </span>
+            <span className="text-muted">
+              12.4k in / 3.2k out
+            </span>
+            <span className="text-muted">
+              (cache: 8.1kr)
+            </span>
+          </div>
+        </div>
+      </Collapsible>
+    </div>
+  )
+}
+
+/** 5. Error bubble — danger-styled message */
+function ErrorBubble({ agent, text }: { agent: string; text: string }) {
+  return (
+    <div className="flex gap-2 min-w-0">
+      <div className="shrink-0 w-6 h-6 rounded-full flex items-center justify-center bg-danger-subtle mt-1">
+        <AlertCircle className="h-3.5 w-3.5 text-danger" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-danger font-mono mb-0.5">{agent}</div>
+        <div className="rounded-r bg-danger-subtle/40 border-l-2 border-l-danger px-3 py-2">
+          <p className="text-xs text-danger leading-relaxed font-mono whitespace-pre-wrap">
+            {text}
+          </p>
+          <button
+            type="button"
+            className="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-danger/30 text-[11px] text-danger font-medium hover:bg-danger-subtle/60 transition-colors"
+          >
+            <RotateCcw className="h-3 w-3" />
+            Restart
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 6. System/status message — centered tiny text */
+function SystemMessage({ text }: { text: string }) {
+  return (
+    <div className="flex items-center justify-center py-px">
+      <span className="text-muted/60 text-[10px] font-mono">{text}</span>
+    </div>
+  )
+}
+
+/** 7. AskUserQuestion card — interactive question with options */
+function QuestionCard({
+  agent,
+  question,
+  options,
+}: {
+  agent: string
+  question: string
+  options: string[]
+}) {
+  const [selected, setSelected] = useState<number | null>(null)
+
+  return (
+    <div className="group/msg flex gap-2 min-w-0">
+      <ChatAvatar name={agent} />
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-muted font-mono mb-0.5">{agent}</div>
+        <div className="rounded-lg border border-border-default bg-surface-raised/60 p-3 max-w-lg">
+          <p className="text-sm text-default mb-3">{question}</p>
+          <div className="flex flex-wrap gap-2">
+            {options.map((opt, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setSelected(i)}
+                className={cn(
+                  "px-3 py-1.5 rounded-md border text-xs font-medium transition-all",
+                  selected === i
+                    ? "border-accent bg-accent/15 text-accent"
+                    : "border-border-default text-secondary hover:border-border-strong hover:bg-surface-sunken/40",
+                )}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+          <p className="text-[10px] text-muted/50 mt-2 font-mono">
+            or type a custom response...
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 8. Todo/task tracking — compact checklist */
+function TodoList({
+  agent,
+  tasks,
+}: {
+  agent: string
+  tasks: { text: string; done: boolean }[]
+}) {
+  return (
+    <div className="group/msg flex gap-2 min-w-0">
+      <ChatAvatar name={agent} />
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-muted font-mono mb-0.5">{agent}</div>
+        <div className="rounded-lg border border-border-default bg-surface-raised/60 p-3 max-w-md">
+          <div className="flex items-center gap-1.5 mb-2">
+            <CheckSquare className="h-3.5 w-3.5 text-info" />
+            <span className="text-xs font-medium text-secondary">Tasks</span>
+            <span className="text-[10px] text-muted font-mono ml-auto">
+              {tasks.filter((t) => t.done).length}/{tasks.length}
+            </span>
+          </div>
+          <div className="space-y-1">
+            {tasks.map((task, i) => (
+              <div key={i} className="flex items-start gap-2">
+                <div
+                  className={cn(
+                    "mt-0.5 h-3.5 w-3.5 rounded border flex items-center justify-center shrink-0",
+                    task.done
+                      ? "bg-success/20 border-success/40"
+                      : "border-border-default",
+                  )}
+                >
+                  {task.done && (
+                    <Check className="h-2.5 w-2.5 text-success" strokeWidth={3} />
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    "text-xs leading-tight",
+                    task.done
+                      ? "text-muted line-through"
+                      : "text-secondary",
+                  )}
+                >
+                  {task.text}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 pt-2 border-t border-border-subtle">
+            <span className="text-[10px] text-muted/50 font-mono">
+              + Add task...
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 9. Activity summary line — inline collapsed */
+function ActivitySummary({
+  agent,
+  text,
+  tools,
+}: {
+  agent: string
+  text: string
+  tools: number
+}) {
+  return (
+    <div className="ml-8">
+      <div className="inline-flex items-center gap-2 border-l-2 border-l-muted/40 rounded-r px-2.5 py-1 hover:bg-surface-sunken/40 transition-colors cursor-pointer">
+        <ChevronRight size={12} className="shrink-0 text-muted" />
+        <AgentAvatar name={agent} size="sm" />
+        <span className="text-xs text-secondary font-medium">{agent}</span>
+        <span className="text-xs text-muted font-mono truncate">{text}</span>
+        {tools > 0 && (
+          <span className="text-[10px] text-muted/60 font-mono shrink-0">
+            (+{tools} tools)
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** 10. Thinking indicator — pulsing dots */
+function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-muted text-[11px] font-mono">
+      <span className="inline-flex items-center gap-[3px]" aria-hidden="true">
+        <span className="animate-pulse-dot h-1 w-1 rounded-full bg-accent" style={{ animationDelay: "0ms" }} />
+        <span className="animate-pulse-dot h-1 w-1 rounded-full bg-accent" style={{ animationDelay: "150ms" }} />
+        <span className="animate-pulse-dot h-1 w-1 rounded-full bg-accent" style={{ animationDelay: "300ms" }} />
+      </span>
+      <span>{label}</span>
+    </span>
+  )
+}
+
+/* ================================================================== */
+/*  SECRETS MODAL                                                      */
+/* ================================================================== */
+
+function SecretsModal({
+  open,
+  onClose,
+  agents,
+}: {
+  open: boolean
+  onClose: () => void
+  agents: FakeAgent[]
+}) {
+  const [secrets, setSecrets] = useState(SECRETS)
+  const [revealed, setRevealed] = useState<Set<string>>(new Set())
+  const [newKey, setNewKey] = useState("")
+  const [newValue, setNewValue] = useState("")
+  const [dirty, setDirty] = useState(false)
+  const [restarted, setRestarted] = useState(false)
+
+  if (!open) return null
+
+  const activeAgents = agents.filter((a) => a.status === "running" || a.status === "idle")
+  const needsRestart = dirty && !restarted
+
+  const toggleReveal = (id: string) => {
+    setRevealed((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleAdd = () => {
+    if (!newKey.trim() || !newValue.trim()) return
+    setSecrets((prev) => [
+      ...prev,
+      { id: `s${Date.now()}`, key: newKey.trim().toUpperCase(), value: newValue.trim(), addedAgo: "just now" },
+    ])
+    setNewKey("")
+    setNewValue("")
+    setDirty(true)
+    setRestarted(false)
+  }
+
+  const handleDelete = (id: string) => {
+    setSecrets((prev) => prev.filter((s) => s.id !== id))
+    setDirty(true)
+    setRestarted(false)
+  }
+
+  const handleRestart = () => {
+    setRestarted(true)
+  }
+
+  const maskValue = (val: string) => {
+    if (val.length <= 8) return "●".repeat(val.length)
+    return val.slice(0, 4) + "●".repeat(Math.min(val.length - 8, 12)) + val.slice(-4)
+  }
+
+  return (
+    <div className="fixed inset-0 z-(--z-overlay) flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-lg mx-4 rounded-xl border border-border-default bg-surface-raised shadow-lg overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4 text-muted" />
+              <h2 className="text-sm font-semibold text-default">Project Secrets</h2>
+            </div>
+            <p className="text-[11px] text-muted mt-0.5 ml-6">
+              Environment variables injected into agent containers
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-sunken/50 transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Secrets list */}
+        <div className="px-5 max-h-[320px] overflow-y-auto">
+          {secrets.length === 0 ? (
+            <div className="py-8 text-center">
+              <KeyRound className="h-8 w-8 text-muted/30 mx-auto mb-2" />
+              <p className="text-xs text-muted">No secrets configured</p>
+            </div>
+          ) : (
+            <div className="space-y-px">
+              {secrets.map((secret) => (
+                <div
+                  key={secret.id}
+                  className="group flex items-center gap-3 py-2.5 border-b border-border-subtle last:border-b-0"
+                >
+                  {/* Key name */}
+                  <div className="flex-1 min-w-0">
+                    <span className="text-xs font-mono font-medium text-default block truncate">
+                      {secret.key}
+                    </span>
+                    <span className="text-[10px] text-muted/50 font-mono">
+                      {secret.addedAgo}
+                    </span>
+                  </div>
+
+                  {/* Value (masked or revealed) */}
+                  <span className="text-[11px] font-mono text-muted truncate max-w-[160px]">
+                    {revealed.has(secret.id) ? secret.value : maskValue(secret.value)}
+                  </span>
+
+                  {/* Actions */}
+                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      type="button"
+                      onClick={() => toggleReveal(secret.id)}
+                      className="p-1 rounded text-muted hover:text-secondary transition-colors"
+                      title={revealed.has(secret.id) ? "Hide" : "Reveal"}
+                    >
+                      {revealed.has(secret.id) ? (
+                        <EyeOff className="h-3 w-3" />
+                      ) : (
+                        <Eye className="h-3 w-3" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(secret.id)}
+                      className="p-1 rounded text-muted hover:text-danger transition-colors"
+                      title="Delete"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Add secret form */}
+        <div className="px-5 py-3 border-t border-border-subtle">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={newKey}
+              onChange={(e) => setNewKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ""))}
+              placeholder="KEY_NAME"
+              className="flex-1 min-w-0 bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs font-mono text-default placeholder:text-muted/40 outline-none focus:border-accent/50 transition-colors"
+            />
+            <input
+              type="password"
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              placeholder="value"
+              className="flex-1 min-w-0 bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs font-mono text-default placeholder:text-muted/40 outline-none focus:border-accent/50 transition-colors"
+            />
+            <button
+              type="button"
+              onClick={handleAdd}
+              disabled={!newKey.trim() || !newValue.trim()}
+              className={cn(
+                "px-3 py-1.5 rounded-md text-xs font-medium transition-colors shrink-0",
+                newKey.trim() && newValue.trim()
+                  ? "bg-accent text-on-emphasis hover:bg-accent-hover"
+                  : "bg-surface-sunken text-muted cursor-not-allowed",
+              )}
+            >
+              Add
+            </button>
+          </div>
+        </div>
+
+        {/* Restart banner */}
+        {needsRestart && activeAgents.length > 0 && (
+          <div className="px-5 py-3 border-t border-warning/20 bg-warning-subtle/30 flex items-center gap-3">
+            <AlertTriangle className="h-3.5 w-3.5 text-warning shrink-0" />
+            <span className="text-xs text-warning flex-1">
+              {activeAgents.length} agent{activeAgents.length !== 1 ? "s" : ""} need restart to pick up changes
+            </span>
+            <button
+              type="button"
+              onClick={handleRestart}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-warning/20 text-warning text-xs font-medium hover:bg-warning/30 transition-colors shrink-0"
+            >
+              <RefreshCw className="h-3 w-3" />
+              Restart All
+            </button>
+          </div>
+        )}
+
+        {/* Restarted confirmation */}
+        {restarted && (
+          <div className="px-5 py-3 border-t border-success/20 bg-success-subtle/30 flex items-center gap-3">
+            <Check className="h-3.5 w-3.5 text-success shrink-0" />
+            <span className="text-xs text-success">
+              {activeAgents.length} agent{activeAgents.length !== 1 ? "s" : ""} restarting with updated environment
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  HEADER BAR                                                         */
+/* ================================================================== */
+
+function HeaderBar({
+  onToggleSidebar,
+  onOpenSecrets,
+  selectedAgent,
+  agents,
+  showSidebarToggle = true,
+}: {
+  onToggleSidebar: () => void
+  onOpenSecrets: () => void
+  selectedAgent: FakeAgent | null
+  agents: FakeAgent[]
+  showSidebarToggle?: boolean
+}) {
+  const totalCost = agents.reduce((sum, a) => sum + a.cost, 0)
+
+  return (
+    <div className="h-12 border-b border-border-default bg-surface-sunken px-4 flex items-center gap-4 shrink-0">
+      {/* Left: sidebar toggle + project name + secrets */}
+      <div className="flex items-center gap-2">
+        {showSidebarToggle && (
+          <button
+            type="button"
+            onClick={onToggleSidebar}
+            className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+          >
+            <PanelLeftClose className="h-4 w-4" />
+          </button>
+        )}
+        <span className="text-sm font-medium text-default">agentobox</span>
+        <button
+          type="button"
+          onClick={onOpenSecrets}
+          className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+          title="Project secrets"
+        >
+          <KeyRound className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Center: selected agent indicator */}
+      <div className="flex-1 flex items-center justify-center">
+        {selectedAgent ? (
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-surface-raised/50 text-xs">
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full shrink-0",
+                selectedAgent.status === "running" && "bg-success animate-breathe text-success",
+                selectedAgent.status === "error" && "bg-danger",
+                selectedAgent.status === "idle" && "bg-info",
+                selectedAgent.status === "stopped" && "bg-muted/50",
+                selectedAgent.status === "waiting" && "bg-warning",
+              )}
+            />
+            <span className="font-medium text-default">{selectedAgent.name}</span>
+            <span className="text-muted">&middot;</span>
+            <span className="text-muted font-mono">{selectedAgent.model}</span>
+            <span
+              className={cn(
+                "text-[10px] capitalize",
+                STATUS_CONFIG[selectedAgent.status]?.text ?? "text-muted",
+              )}
+            >
+              {selectedAgent.status}
+            </span>
+          </div>
+        ) : (
+          <span className="text-xs text-muted">
+            All agents ({agents.length})
+          </span>
+        )}
+      </div>
+
+      {/* Right: total cost */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted font-mono">
+          {formatCost(totalCost)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  SESSION INFO BAR                                                   */
+/* ================================================================== */
+
+function SessionInfoBar({ agent }: { agent: FakeAgent | null }) {
+  if (!agent) return null
+
+  const items = [
+    agent.model,
+    "47 tools",
+    formatCost(agent.cost),
+    `${agent.turns} turn${agent.turns === 1 ? "" : "s"}`,
+    "default",
+    agent.phase,
+  ].filter(Boolean)
+
+  return (
+    <div className="h-8 border-b border-border-default bg-surface px-4 flex items-center gap-2 shrink-0">
+      {items.map((item, i) => (
+        <span key={i} className="text-xs text-muted flex items-center gap-2">
+          {i > 0 && <span className="text-muted">&middot;</span>}
+          <span className="font-mono">{item}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  COMPOSER BAR                                                       */
+/* ================================================================== */
+
+function ComposerBar({ selectedAgent }: { selectedAgent: FakeAgent | null }) {
+  const placeholder = selectedAgent
+    ? `Message ${selectedAgent.name}...`
+    : "Message team lead... (type @ to target)"
+
+  return (
+    <div className="px-6 pb-4 pt-2 max-w-3xl mx-auto w-full shrink-0">
+      <div className="relative rounded-2xl border-[0.5px] border-border-default bg-surface-raised/60">
+        {/* Text input */}
+        <textarea
+          readOnly
+          placeholder={placeholder}
+          rows={1}
+          className="w-full bg-transparent border-none outline-none resize-none px-4 pt-4 pb-2 text-sm text-default placeholder:text-muted min-h-[52px] max-h-[40vh]"
+        />
+
+        {/* Toolbar row */}
+        <div className="flex items-center justify-between px-3 pb-3">
+          {/* Left side */}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled
+              className="rounded-lg p-1.5 text-muted cursor-not-allowed opacity-50"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium text-muted">
+              <Code className="h-3 w-3" />
+              Normal
+            </span>
+            {selectedAgent && (
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-surface-sunken text-xs text-secondary font-medium">
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full",
+                    selectedAgent.status === "running" ? "bg-success" : selectedAgent.status === "idle" ? "bg-info" : "bg-muted",
+                  )}
+                />
+                {selectedAgent.name}
+              </span>
+            )}
+          </div>
+
+          {/* Right side */}
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-muted tabular-nums">$0.30</span>
+            <button
+              type="button"
+              className="flex items-center justify-center h-8 w-8 rounded-full bg-surface-sunken text-muted cursor-not-allowed"
+            >
+              <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  CHAT FEED                                                          */
+/* ================================================================== */
+
+function ChatFeed({ selectedAgent }: { selectedAgent: FakeAgent | null }) {
+  return (
+    <div className="flex flex-col h-full min-w-0">
+      <SessionInfoBar agent={selectedAgent} />
+
+      <ScrollArea className="flex-1 overflow-y-auto dotted-grid">
+        <div className="max-w-3xl mx-auto w-full px-6 py-4 space-y-3">
+          {/* 6. System init message */}
+          <SystemMessage text="Opus 4.6 · 47 tools" />
+          <SystemMessage text="session initialized" />
+
+          {/* 1. User message */}
+          <UserMessage text="Fix the JWT validation bug in auth.ts. The token expiry check is off by one hour." />
+
+          {/* 2. Assistant message with markdown */}
+          <AssistantMessage
+            agent="backend"
+            content={FAKE_MARKDOWN}
+          />
+
+          {/* 3. Single tool call */}
+          <SingleToolRow toolName="Read" summary="src/auth.ts" />
+
+          {/* 9. Activity summary */}
+          <ActivitySummary
+            agent="frontend"
+            text="Reading component styles"
+            tools={2}
+          />
+
+          {/* 2b. Assistant follow-up (no avatar — same agent) */}
+          <AssistantMessage
+            agent="backend"
+            content="I've applied the fix. Let me also run the linter and verify the tests pass."
+            showAvatar={false}
+          />
+
+          {/* 3b. Multi-tool group */}
+          <MultiToolGroup
+            tools={[
+              { name: "Edit", summary: "src/auth.ts" },
+              { name: "Bash", summary: "npm run lint" },
+              { name: "Bash", summary: "npm test -- --filter auth" },
+            ]}
+          />
+
+          {/* 7. AskUserQuestion card */}
+          <QuestionCard
+            agent="backend"
+            question="The fix is ready. How should I handle the clock skew tolerance?"
+            options={[
+              "30 seconds (Recommended)",
+              "60 seconds",
+              "No tolerance",
+              "Configurable via env var",
+            ]}
+          />
+
+          {/* 1b. User reply */}
+          <UserMessage text="Go with 30 seconds. That's the standard." />
+
+          {/* 5. Error bubble */}
+          <ErrorBubble
+            agent="qa"
+            text={"npm test failed: FAIL src/auth.test.ts\n\nExpected: 200\nReceived: 401\n\nThe auth.ts fix hasn't landed in the test environment yet."}
+          />
+
+          {/* 10. Thinking indicator */}
+          <div className="flex gap-2 min-w-0">
+            <ChatAvatar name="backend" />
+            <div className="min-w-0 flex-1">
+              <div className="text-[11px] text-muted font-mono mb-0.5">backend</div>
+              <ThinkingIndicator label="Applying clock skew fix..." />
+            </div>
+          </div>
+
+          {/* 4. Result pill */}
+          <ResultPill
+            cost={0.12}
+            duration="3m 22s"
+            turns={8}
+            model="Opus 4.6"
+          />
+
+          {/* 8. Todo list */}
+          <TodoList
+            agent="backend"
+            tasks={[
+              { text: "Read auth.ts and identify the bug", done: true },
+              { text: "Fix Date.now() → seconds conversion", done: true },
+              { text: "Add 30s clock skew tolerance", done: true },
+              { text: "Run linter", done: true },
+              { text: "Run auth test suite", done: false },
+              { text: "Update error logging", done: false },
+            ]}
+          />
+
+          {/* 6b. Status message */}
+          <SystemMessage text="backend session complete · 8 turns · $0.12" />
+        </div>
+      </ScrollArea>
+
+      <ComposerBar selectedAgent={selectedAgent} />
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  ROSTER PANEL                                                       */
+/* ================================================================== */
+
+function RosterPanel({
+  collapsed,
+  onToggle,
+  agents,
+  selectedAgentId,
+  onSelectAgent,
+}: {
+  collapsed: boolean
+  onToggle: () => void
+  agents: FakeAgent[]
+  selectedAgentId: string | null
+  onSelectAgent: (id: string | null) => void
+}) {
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0 }
+    for (const a of agents) counts[a.status] = (counts[a.status] ?? 0) + 1
+    return counts
+  }, [agents])
+
+  return (
+    <div
+      className="h-full bg-surface-sunken border-r-[0.5px] border-border-default flex flex-col overflow-hidden shrink-0"
+      style={{
+        width: collapsed ? 60 : 260,
+        minWidth: collapsed ? 60 : 260,
+        transition: "width 200ms ease, min-width 200ms ease",
+      }}
+    >
+      <div className="flex-1 flex flex-col bg-surface min-h-0">
+        {/* Header — h-8 to align with session info bar + right panel tab bar */}
+        <div className={cn(
+          "h-8 px-3 flex items-center border-b border-border-default shrink-0",
+          collapsed && "justify-center px-1.5",
+        )}>
+          {!collapsed && (
+            <div className="flex items-center gap-1.5 flex-1 min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+                Agents
+              </span>
+              <div className="flex items-center gap-1.5 ml-1">
+                {PILL_CONFIG.map(
+                  (pill) =>
+                    (statusCounts[pill.key] ?? 0) > 0 && (
+                      <span
+                        key={pill.key}
+                        className={cn(
+                          "inline-flex items-center gap-0.5 font-mono text-[10px] tabular-nums",
+                          pill.text,
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "h-1.5 w-1.5 rounded-full shrink-0",
+                            pill.dot,
+                            pill.animate && "animate-breathe text-success",
+                          )}
+                        />
+                        {statusCounts[pill.key]}
+                      </span>
+                    ),
+                )}
+              </div>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onToggle}
+            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors shrink-0"
+            aria-label={collapsed ? "Expand roster" : "Collapse roster"}
+          >
+            {collapsed ? (
+              <PanelLeftOpen className="h-3.5 w-3.5" />
+            ) : (
+              <PanelLeftClose className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
+
+        {/* Agent list */}
+        <ScrollArea className="flex-1 overflow-y-auto">
+          <div className="flex flex-col pt-1.5 pb-2">
+            {/* All agents button */}
+            {!collapsed && (
+              <button
+                type="button"
+                onClick={() => onSelectAgent(null)}
+                className={cn(
+                  "mx-1.5 rounded-lg transition-all duration-(--duration-normal) text-left px-3 py-2",
+                  "border-l-2 border-transparent",
+                  selectedAgentId === null
+                    ? "bg-surface-raised/80 border-l-accent"
+                    : "hover:bg-surface-raised/30",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
+                  <span
+                    className={cn(
+                      "text-[13px] font-medium",
+                      selectedAgentId === null ? "text-default" : "text-secondary",
+                    )}
+                  >
+                    All agents
+                  </span>
+                  <span className="flex-1" />
+                  <span className="text-[10px] text-muted tabular-nums font-mono">
+                    {agents.length}
+                  </span>
+                </div>
+              </button>
+            )}
+
+            {agents.map((agent) => {
+              const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
+              const isSelected = selectedAgentId === agent.id
+              const isRunning = agent.status === "running"
+              const isError = agent.status === "error"
+              const isStopped = agent.status === "stopped"
+
+              if (collapsed) {
+                return (
+                  <button
+                    key={agent.id}
+                    type="button"
+                    onClick={() => onSelectAgent(agent.id)}
+                    className={cn(
+                      "mx-auto my-0.5 relative group",
+                      isStopped && "opacity-55",
+                    )}
+                    title={agent.name}
+                  >
+                    <AgentAvatar name={agent.name} size="md" stopped={isStopped} />
+                    <span
+                      className={cn(
+                        "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface",
+                        config.dot,
+                        isRunning && "animate-breathe text-success",
+                      )}
+                    />
+                    {isSelected && (
+                      <span className="absolute inset-0 rounded-md ring-2 ring-accent/50" />
+                    )}
+                  </button>
+                )
+              }
+
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  onClick={() => onSelectAgent(agent.id)}
+                  className={cn(
+                    "group mx-1.5 rounded-lg transition-all duration-(--duration-normal) text-left",
+                    "border-l-2 border-transparent",
+                    isSelected && "bg-surface-raised/80 border-l-accent",
+                    !isSelected && "hover:bg-surface-raised/30",
+                    isError && !isSelected && "hover:bg-danger-subtle",
+                    isError && isSelected && "bg-danger-subtle/60 border-l-danger",
+                    isStopped && "opacity-55",
+                    isRunning && !isSelected && "animate-border-pulse",
+                  )}
+                >
+                  <div className="flex items-start gap-2 px-2.5 py-2">
+                    <AgentAvatar name={agent.name} stopped={isStopped} />
+                    <div className="flex-1 min-w-0">
+                      {/* Row 1: status dot + name + meta */}
+                      <div className="flex items-center gap-1.5">
+                        <span
+                          className={cn(
+                            "h-1.5 w-1.5 rounded-full shrink-0",
+                            config.dot,
+                            isRunning && "animate-breathe text-success",
+                          )}
+                        />
+                        <span
+                          className={cn(
+                            "text-[13px] font-medium truncate",
+                            isSelected ? "text-default" : "text-secondary",
+                            isStopped && "text-muted",
+                          )}
+                        >
+                          {agent.name}
+                        </span>
+                        <span className="flex-1" />
+                        {isError ? (
+                          <span className="text-[9px] font-semibold uppercase tracking-wide text-danger shrink-0">
+                            err
+                          </span>
+                        ) : (
+                          <span className="text-[10px] text-muted/60 shrink-0 tabular-nums font-mono">
+                            {agent.duration}
+                          </span>
+                        )}
+                      </div>
+                      {/* Row 2: activity + cost */}
+                      <div className="flex items-center gap-1 mt-px">
+                        <span
+                          className={cn(
+                            "text-[11px] truncate flex-1 leading-tight",
+                            isError ? "text-danger/80" : "text-muted/70",
+                          )}
+                        >
+                          {agent.task}
+                        </span>
+                        {agent.cost > 0 && (
+                          <span className="text-[9px] text-muted/50 font-mono shrink-0 tabular-nums">
+                            {formatCost(agent.cost)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </ScrollArea>
+
+        {/* Bottom bar */}
+        <div className="px-3 py-2 flex items-center shrink-0 border-t border-border-default">
+          {!collapsed && (
+            <span className="text-[11px] text-muted truncate">vahid@agentobox</span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  AGENT CARDS + VNC PANEL (unified)                                  */
+/* ================================================================== */
+
+/** VNC thumbnail placeholder — aspect ratio matches a 16:10 display */
+function VncThumbnail({ agent }: { agent: FakeAgent }) {
+  const isRunning = agent.status === "running"
+  const isStopped = agent.status === "stopped"
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border overflow-hidden bg-surface-sunken/40 flex flex-col",
+        isRunning ? "border-border-default" : "border-border-subtle",
+        isStopped && "opacity-50",
+      )}
+    >
+      {/* VNC viewport — 16:10 aspect ratio */}
+      <div className="relative w-full" style={{ aspectRatio: "16 / 10" }}>
+        {/* Simulated desktop content */}
+        <div className="absolute inset-0 flex flex-col">
+          {/* Fake title bar */}
+          <div className="h-4 bg-[hsl(220_10%_13%)] flex items-center px-2 gap-1 shrink-0">
+            <span className="h-1.5 w-1.5 rounded-full bg-danger/60" />
+            <span className="h-1.5 w-1.5 rounded-full bg-warning/60" />
+            <span className="h-1.5 w-1.5 rounded-full bg-success/60" />
+            <span className="ml-2 text-[7px] text-muted/40 font-mono truncate">
+              {agent.name} — {isRunning ? agent.task : isStopped ? "session ended" : agent.status}
+            </span>
+          </div>
+          {/* Fake terminal content */}
+          <div className="flex-1 bg-[hsl(220_12%_10%)] p-1.5 overflow-hidden">
+            {isRunning ? (
+              <div className="space-y-0.5">
+                <p className="text-[6px] font-mono text-success/50 leading-tight">$ claude</p>
+                <p className="text-[6px] font-mono text-muted/30 leading-tight truncate">{agent.lastOutput}</p>
+                <p className="text-[6px] font-mono text-accent/40 leading-tight">
+                  <span className="animate-pulse">▊</span>
+                </p>
+              </div>
+            ) : isStopped ? (
+              <div className="flex items-center justify-center h-full">
+                <span className="text-[7px] font-mono text-muted/20">session ended</span>
+              </div>
+            ) : agent.status === "error" ? (
+              <div className="space-y-0.5">
+                <p className="text-[6px] font-mono text-danger/50 leading-tight">Error: {agent.task}</p>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-full">
+                <span className="text-[7px] font-mono text-muted/25">{agent.status}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Live indicator overlay */}
+        {isRunning && (
+          <div className="absolute top-1 right-1 inline-flex items-center gap-1 rounded bg-black/50 px-1 py-px">
+            <span className="h-1 w-1 rounded-full bg-success animate-breathe text-success" />
+            <span className="text-[6px] text-success font-mono">live</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Unified agent card: info + VNC preview side by side */
+function AgentCardRow({
+  agent,
+  isSelected,
+  onSelect,
+  compact = false,
+}: {
+  agent: FakeAgent
+  isSelected: boolean
+  onSelect: () => void
+  compact?: boolean
+}) {
+  const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
+  const isRunning = agent.status === "running"
+  const isError = agent.status === "error"
+  const isStopped = agent.status === "stopped"
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "w-full text-left rounded-lg border transition-all duration-(--duration-normal)",
+        isSelected
+          ? "border-accent/40 bg-surface-raised/80 shadow-sm"
+          : "border-border-subtle bg-surface hover:bg-surface-raised/40 hover:border-border-default",
+        isError && "border-danger/30",
+        isStopped && "opacity-60",
+      )}
+    >
+      <div className={cn("grid gap-2", compact ? "grid-cols-1 p-2.5" : "grid-cols-2 p-3")}>
+        {/* Left: agent info */}
+        <div className="min-w-0 flex flex-col">
+          {/* Header: avatar + name + status */}
+          <div className="flex items-center gap-2 mb-1.5">
+            <AgentAvatar name={agent.name} stopped={isStopped} />
+            <span
+              className={cn(
+                "text-[13px] font-medium flex-1 truncate",
+                isStopped ? "text-muted" : "text-default",
+              )}
+            >
+              {agent.name}
+            </span>
+            <span
+              className={cn(
+                "h-2 w-2 rounded-full shrink-0",
+                config.dot,
+                isRunning && "animate-breathe text-success",
+              )}
+            />
+          </div>
+
+          {/* Current task */}
+          <div className="flex items-start gap-1.5 mb-1">
+            <Terminal className="h-3 w-3 text-muted/60 shrink-0 mt-0.5" />
+            <span className="text-[11px] text-secondary leading-tight truncate">
+              {agent.task}
+            </span>
+          </div>
+
+          {/* Last output */}
+          <div className="rounded bg-surface-sunken/60 px-1.5 py-1 mb-1.5 flex-1">
+            <p className="text-[10px] text-muted font-mono leading-relaxed line-clamp-2 whitespace-pre-wrap">
+              {agent.lastOutput}
+            </p>
+          </div>
+
+          {/* Stats row */}
+          <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap">
+            <span className="inline-flex items-center gap-0.5">
+              <DollarSign className="h-2.5 w-2.5" />
+              {formatCost(agent.cost)}
+            </span>
+            <span className="inline-flex items-center gap-0.5">
+              <Clock className="h-2.5 w-2.5" />
+              {agent.duration}
+            </span>
+            <span className="text-muted/50">&middot;</span>
+            <span>{agent.model}</span>
+          </div>
+        </div>
+
+        {/* Right: VNC thumbnail */}
+        <VncThumbnail agent={agent} />
+      </div>
+    </button>
+  )
+}
+
+function AgentCardsPanel({
+  agents,
+  selectedAgentId,
+  onSelectAgent,
+  compact = false,
+}: {
+  agents: FakeAgent[]
+  selectedAgentId: string | null
+  onSelectAgent: (id: string) => void
+  compact?: boolean
+}) {
+  return (
+    <ScrollArea className="h-full overflow-y-auto">
+      <div className="p-3 space-y-2">
+        {agents.map((agent) => (
+          <AgentCardRow
+            key={agent.id}
+            agent={agent}
+            isSelected={selectedAgentId === agent.id}
+            onSelect={() => onSelectAgent(agent.id)}
+            compact={compact}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}
+
+/* ================================================================== */
+/*  TAB BAR                                                            */
+/* ================================================================== */
+
+function TabBar({
+  tabs,
+  activeTab,
+  onTabChange,
+}: {
+  tabs: { id: string; label: string; icon: React.ReactNode }[]
+  activeTab: string
+  onTabChange: (id: string) => void
+}) {
+  return (
+    <div className="h-8 flex items-center gap-1 px-3 border-b border-border-default bg-surface shrink-0">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => onTabChange(tab.id)}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+            activeTab === tab.id
+              ? "bg-surface-raised text-default"
+              : "text-muted hover:text-secondary hover:bg-surface-raised/30",
+          )}
+        >
+          {tab.icon}
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  BREAKPOINT INDICATOR                                               */
+/* ================================================================== */
+
+function BreakpointIndicator({ bp }: { bp: Breakpoint }) {
+  const labels: Record<Breakpoint, { text: string; width: string }> = {
+    XL: { text: "XL", width: "\u22651920" },
+    L: { text: "L", width: "1440-1919" },
+    M: { text: "M", width: "1280-1439" },
+    S: { text: "S", width: "1024-1279" },
+    mobile: { text: "Mobile", width: "<1024" },
+  }
+
+  const info = labels[bp]
+
+  return (
+    <div className="fixed bottom-4 right-4 z-(--z-toast) inline-flex items-center gap-1.5 rounded-full bg-surface-overlay border border-border-default shadow-lg px-3 py-1.5">
+      <span className="h-2 w-2 rounded-full bg-accent" />
+      <span className="text-[11px] font-semibold text-default">{info.text}</span>
+      <span className="text-[10px] text-muted font-mono">{info.width}px</span>
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  PANEL HEADER (shared between Agent Activity + Screen)              */
+/* ================================================================== */
+
+function PanelHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="h-8 px-3 flex items-center border-b border-border-default shrink-0">
+      {children}
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  RESIZE HANDLE                                                      */
+/* ================================================================== */
+
+/** Drag handle for resizable panels. Place on the leading edge of the panel. */
+function ResizeHandle({
+  onResize,
+  side = "left",
+}: {
+  onResize: (delta: number) => void
+  side?: "left" | "right"
+}) {
+  const dragging = useRef(false)
+  const lastX = useRef(0)
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      dragging.current = true
+      lastX.current = e.clientX
+      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+    },
+    [],
+  )
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging.current) return
+      const delta = e.clientX - lastX.current
+      lastX.current = e.clientX
+      // For left-edge handle: dragging left = positive resize (panel grows)
+      onResize(side === "left" ? -delta : delta)
+    },
+    [onResize, side],
+  )
+
+  const onPointerUp = useCallback(() => {
+    dragging.current = false
+  }, [])
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      className={cn(
+        "absolute top-0 bottom-0 w-1 z-(--z-dropdown) cursor-col-resize group/resize",
+        side === "left" ? "left-0" : "right-0",
+      )}
+    >
+      {/* Visual indicator on hover/drag */}
+      <div className="absolute inset-y-0 left-0 w-px bg-transparent group-hover/resize:bg-accent/50 group-active/resize:bg-accent transition-colors" />
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  MAIN PAGE                                                          */
+/* ================================================================== */
+
+export default function PrototypePage() {
+  const bp = useBreakpoint()
+  const [rosterCollapsed, setRosterCollapsed] = useState(false)
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>("1")
+  const [mainTab, setMainTab] = useState<"chat" | "agents">("chat")
+  const [secretsOpen, setSecretsOpen] = useState(false)
+  const [rightPanelWidth, setRightPanelWidth] = useState<number | null>(null)
+
+  // Auto-collapse roster at M breakpoint
+  useEffect(() => {
+    if (bp === "M") setRosterCollapsed(true)
+    if (bp === "L" || bp === "XL") setRosterCollapsed(false)
+  }, [bp])
+
+  // Reset custom width when breakpoint changes
+  useEffect(() => {
+    setRightPanelWidth(null)
+  }, [bp])
+
+  const selectedAgent = useMemo(
+    () => AGENTS.find((a) => a.id === selectedAgentId) ?? null,
+    [selectedAgentId],
+  )
+
+  const handleSelectAgent = useCallback((id: string | null) => {
+    setSelectedAgentId(id)
+  }, [])
+
+  // Determine what's visible at each breakpoint
+  const showRoster = bp !== "mobile"
+  const showRightPanel = bp === "XL" || bp === "L" || bp === "M"
+  const showTopTabs = bp === "S" || bp === "mobile"
+
+  // Right panel width: custom if user has resized, else breakpoint default
+  const defaultRightWidth = bp === "M" ? 340 : 480
+  const effectiveRightWidth = rightPanelWidth ?? defaultRightWidth
+  // Compact mode when panel is narrow enough that side-by-side doesn't work
+  const compactCards = effectiveRightWidth < 400
+
+  const handleRightPanelResize = useCallback((delta: number) => {
+    setRightPanelWidth((prev) => {
+      const current = prev ?? defaultRightWidth
+      // Clamp between 280 and 720
+      return Math.max(280, Math.min(720, current + delta))
+    })
+  }, [defaultRightWidth])
+
+  // Top tabs (small screens — no separate Screen tab since VNC is inline with agents)
+  const topTabs = [
+    { id: "chat", label: "Chat", icon: <MessageSquare className="h-3.5 w-3.5" /> },
+    { id: "agents", label: "Agents", icon: <Users className="h-3.5 w-3.5" /> },
+  ]
+
+  return (
+    <div className="h-screen flex flex-col bg-surface overflow-hidden">
+      {/* Header bar */}
+      <HeaderBar
+        onToggleSidebar={() => setRosterCollapsed((c) => !c)}
+        onOpenSecrets={() => setSecretsOpen(true)}
+        selectedAgent={selectedAgent}
+        agents={AGENTS}
+        showSidebarToggle={showRoster}
+      />
+
+      {/* Secrets modal */}
+      <SecretsModal
+        open={secretsOpen}
+        onClose={() => setSecretsOpen(false)}
+        agents={AGENTS}
+      />
+
+      {/* Top tabs (S + mobile) */}
+      {showTopTabs && (
+        <TabBar
+          tabs={topTabs}
+          activeTab={mainTab}
+          onTabChange={(id) => setMainTab(id as "chat" | "agents")}
+        />
+      )}
+
+      {/* Main layout */}
+      <div className="flex-1 flex min-h-0 overflow-hidden">
+        {/* Roster */}
+        {showRoster && (
+          <RosterPanel
+            collapsed={rosterCollapsed || bp === "M"}
+            onToggle={() => setRosterCollapsed((c) => !c)}
+            agents={AGENTS}
+            selectedAgentId={selectedAgentId}
+            onSelectAgent={handleSelectAgent}
+          />
+        )}
+
+        {/* Center: chat feed */}
+        {(!showTopTabs || mainTab === "chat") && (
+          <div className="flex-1 min-w-0 flex flex-col">
+            <ChatFeed selectedAgent={selectedAgent} />
+          </div>
+        )}
+
+        {/* Right panel: unified agent cards with inline VNC */}
+        {showRightPanel && (
+          <div
+            className="relative border-l border-border-default bg-surface flex flex-col shrink-0"
+            style={{
+              width: effectiveRightWidth,
+              minWidth: effectiveRightWidth,
+            }}
+          >
+            <ResizeHandle onResize={handleRightPanelResize} side="left" />
+            <PanelHeader>
+              <div className="flex items-center gap-2">
+                <Users className="h-3.5 w-3.5 text-muted" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+                  Agent Activity
+                </span>
+              </div>
+            </PanelHeader>
+            <AgentCardsPanel
+              agents={AGENTS}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={(id) => setSelectedAgentId(id)}
+              compact={compactCards}
+            />
+          </div>
+        )}
+
+        {/* Top-tab content: agents (S + mobile) */}
+        {showTopTabs && mainTab === "agents" && (
+          <div className="flex-1 min-w-0 bg-surface">
+            <AgentCardsPanel
+              agents={AGENTS}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={(id) => setSelectedAgentId(id)}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Breakpoint indicator */}
+      <BreakpointIndicator bp={bp} />
+    </div>
+  )
+}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -2854,7 +2854,7 @@ function ResizeHandle({
 export default function PrototypePage() {
   const bp = useBreakpoint()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(["1"]))
-  const [mainTab, setMainTab] = useState<"chat" | "agents">("chat")
+  const [mainTab, setMainTab] = useState<"chat" | "agents" | "skills">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
   const [agentPanelOpen, setAgentPanelOpen] = useState(true)
   const [leftPanelWidth, setLeftPanelWidth] = useState<number | null>(null)
@@ -2902,6 +2902,7 @@ export default function PrototypePage() {
   const topTabs = [
     { id: "chat", label: "Chat", icon: <MessageSquare className="h-3.5 w-3.5" /> },
     { id: "agents", label: "Agents", icon: <Users className="h-3.5 w-3.5" /> },
+    { id: "skills", label: "Skills", icon: <BookOpen className="h-3.5 w-3.5" /> },
   ]
 
   return (
@@ -2938,7 +2939,7 @@ export default function PrototypePage() {
           <TabBar
             tabs={topTabs}
             activeTab={mainTab}
-            onTabChange={(id) => setMainTab(id as "chat" | "agents")}
+            onTabChange={(id) => setMainTab(id as "chat" | "agents" | "skills")}
           />
         )}
 
@@ -2957,6 +2958,13 @@ export default function PrototypePage() {
               expandedIds={expandedIds}
               onToggleAgent={handleToggleAgent}
             />
+          </div>
+        )}
+
+        {/* Top-tab content: skills (S + mobile) */}
+        {showTopTabs && mainTab === "skills" && (
+          <div className="flex-1 min-w-0 bg-surface overflow-hidden">
+            <SkillsPanel allExpanded={false} />
           </div>
         )}
       </div>

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -49,6 +49,8 @@ type FakeAgent = {
   /** Live one-liner: last tool call or action, continuously updated.
    *  SOURCE: latest tool_use content block name + summary from StreamEvent */
   liveAction?: string
+  /** Compact todo progress for live status bar */
+  todoProgress?: { done: number; total: number }
   instructions: string
   mcpServers: string[]
   runtime: "docker" | "modal"
@@ -68,6 +70,7 @@ const AGENTS: FakeAgent[] = [
     lastOutput: "Applied fix to validateToken()...",
     phase: "Editing",
     liveAction: "Edit src/auth.ts (+3 -1)",
+    todoProgress: { done: 5, total: 6 },
     instructions: "Django 6.0 backend: models, services, auth, GraphQL schema. Run tests before committing.",
     mcpServers: ["computer-use"],
     runtime: "docker",
@@ -811,6 +814,26 @@ function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
       </span>
       <span>{label}</span>
     </span>
+  )
+}
+
+/** 10b. Live status bar — pinned between feed and composer in agent detail */
+function LiveStatusBar({ agent }: { agent: FakeAgent }) {
+  return (
+    <div className="px-3 py-1.5 border-t border-border-subtle bg-surface-sunken/20 flex items-center gap-2 min-h-[28px]">
+      <span className="h-1.5 w-1.5 rounded-full bg-accent animate-breathe shrink-0" />
+      <span className="text-[11px] font-mono text-secondary truncate">
+        {agent.liveAction || "Working..."}
+      </span>
+      {agent.todoProgress && (
+        <span className="ml-auto flex items-center gap-1 shrink-0">
+          <CheckSquare className="h-3 w-3 text-muted/60" />
+          <span className="text-[10px] font-mono text-muted">
+            {agent.todoProgress.done}/{agent.todoProgress.total}
+          </span>
+        </span>
+      )}
+    </div>
   )
 }
 
@@ -1861,7 +1884,7 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
   const isError = agent.status === "error"
 
   return (
-    <div className="border-t border-border-subtle">
+    <div className="border-t border-border-subtle flex flex-col">
       {/* Mini-feed header */}
       <div className="px-3 py-1.5 flex items-center gap-2 bg-surface-sunken/30">
         <MessageSquare className="h-3 w-3 text-muted/60" />
@@ -1873,14 +1896,10 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
         </span>
       </div>
 
-      {/* Verbose content — scrollable mini-feed */}
-      <div className="max-h-[320px] overflow-y-auto px-3 py-2 space-y-2">
-        {/* Show different content based on agent */}
+      {/* Historical content only — scrollable mini-feed */}
+      <div className="flex-1 min-h-0 max-h-[320px] overflow-y-auto px-3 py-2 space-y-2">
         {agent.name === "backend" ? (
           <>
-            {/* Thinking indicator (source: thinking content block) */}
-            <ThinkingIndicator label="Analyzing auth.ts..." />
-
             {/* Tool calls (source: tool_use content blocks) */}
             <SingleToolRow toolName="Read" summary="src/auth.ts" />
             <SingleToolRow toolName="Read" summary="src/middleware/auth.ts" />
@@ -1909,21 +1928,6 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
 
             {/* Result pill (source: result message) */}
             <ResultPill cost={agent.cost} duration={agent.duration} turns={agent.turns} model={agent.model} />
-
-            {/* Todo list (source: TodoWrite tool_use blocks) */}
-            {isRunning && (
-              <TodoList
-                agent={agent.name}
-                tasks={[
-                  { text: "Read auth.ts and identify the bug", done: true },
-                  { text: "Fix Date.now() → seconds conversion", done: true },
-                  { text: "Add 30s clock skew tolerance", done: true },
-                  { text: "Add refresh token rotation", done: true },
-                  { text: "Run linter", done: true },
-                  { text: "Update test fixtures", done: false },
-                ]}
-              />
-            )}
           </>
         ) : agent.name === "qa" ? (
           <>
@@ -1946,7 +1950,6 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
           </>
         ) : agent.name === "frontend" ? (
           <>
-            <ThinkingIndicator label="Reading component styles..." />
             <SingleToolRow toolName="Read" summary="src/components/Button.tsx" />
             <SingleToolRow toolName="Read" summary="src/styles/tokens.css" />
             <AssistantMessage
@@ -1980,6 +1983,9 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
           </div>
         )}
       </div>
+
+      {/* Live status bar — pinned between feed and composer */}
+      {isRunning && <LiveStatusBar agent={agent} />}
 
       {/* Mini composer — message this specific agent */}
       <div className="px-3 py-2 border-t border-border-subtle">

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -12,7 +12,6 @@ import {
   X,
   AlertCircle,
   Plus,
-  Code,
   Terminal,
   Clock,
   DollarSign,
@@ -29,6 +28,7 @@ import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Collapsible } from "@/components/ui/collapsible"
 import { MarkdownRenderer } from "@/components/shared/markdown-renderer"
+import { CopyButton } from "@/components/shared/copy-button"
 
 /* ================================================================== */
 /*  FAKE DATA                                                          */
@@ -37,7 +37,7 @@ import { MarkdownRenderer } from "@/components/shared/markdown-renderer"
 type FakeAgent = {
   id: string
   name: string
-  status: "running" | "error" | "idle" | "stopped" | "waiting"
+  status: "running" | "error" | "idle" | "stopped" | "waiting" | "deploying"
   task: string
   cost: number
   duration: string
@@ -45,6 +45,9 @@ type FakeAgent = {
   turns: number
   lastOutput: string
   phase?: string
+  /** Live one-liner: last tool call or action, continuously updated.
+   *  SOURCE: latest tool_use content block name + summary from StreamEvent */
+  liveAction?: string
 }
 
 const AGENTS: FakeAgent[] = [
@@ -59,6 +62,7 @@ const AGENTS: FakeAgent[] = [
     turns: 8,
     lastOutput: "Applied fix to validateToken()...",
     phase: "Editing",
+    liveAction: "Edit src/auth.ts (+3 -1)",
   },
   {
     id: "2",
@@ -71,6 +75,7 @@ const AGENTS: FakeAgent[] = [
     turns: 4,
     lastOutput: "Scanning tailwind classes in Button...",
     phase: "Reading",
+    liveAction: "Read src/components/Button.tsx",
   },
   {
     id: "3",
@@ -82,6 +87,7 @@ const AGENTS: FakeAgent[] = [
     model: "Sonnet 4.6",
     turns: 3,
     lastOutput: "FAIL src/auth.test.ts\nExpected 200, received 401",
+    liveAction: "Bash npm test -- --filter auth",
   },
   {
     id: "4",
@@ -104,6 +110,18 @@ const AGENTS: FakeAgent[] = [
     model: "Haiku 4.5",
     turns: 2,
     lastOutput: "Updated API reference section",
+    liveAction: "Edit docs/api-reference.md (+12 -3)",
+  },
+  {
+    id: "6",
+    name: "infra",
+    status: "deploying" as const,
+    task: "Provisioning container",
+    cost: 0.00,
+    duration: "0m 12s",
+    model: "Haiku 4.5",
+    turns: 0,
+    lastOutput: "Initializing workspace...",
   },
 ]
 
@@ -121,6 +139,11 @@ const SECRETS: FakeSecret[] = [
   { id: "s4", key: "OPENAI_API_KEY", value: "sk-proj-xxxxxxxxxxxxxxxx", addedAgo: "1w ago" },
 ]
 
+/**
+ * FAKE_MARKDOWN — used in right-panel agent detail feed.
+ * SOURCE: TimelineEntry.content (full assistant message content blocks)
+ * This is the VERBOSE output — only shown when drilling into an agent.
+ */
 const FAKE_MARKDOWN = `I've analyzed the JWT validation issue. The problem is in \`validateToken()\` — the expiry comparison uses **seconds** but \`Date.now()\` returns **milliseconds**.
 
 Here's the fix:
@@ -145,6 +168,121 @@ The changes needed:
 | Silent failures | Structured logging |`
 
 /* ================================================================== */
+/*  TEAM FEED DATA — main feed shows summaries, not verbose output    */
+/*                                                                     */
+/*  Data sources:                                                      */
+/*  - "summary" items → TimelineEntry.summary (agent turn result)     */
+/*  - "user" items → user messages (sent via composer / @mention)     */
+/*  - "status" items → agent status transitions (StreamEvent)         */
+/*  - "error" items → agent error events (StreamEvent with isError)   */
+/*  - "system" items → session lifecycle events                        */
+/*  - "question" items → AskUserQuestion tool_use in content blocks   */
+/* ================================================================== */
+
+type TeamFeedItem =
+  | { type: "system"; text: string }
+  | { type: "user"; text: string; target?: string }
+  | { type: "summary"; agent: string; summary: string; cost: number; turns: number; duration: string; isError?: boolean }
+  | { type: "status"; agent: string; from: string; to: string }
+  | { type: "error"; agent: string; text: string }
+  | { type: "question"; agent: string; question: string; options: string[] }
+
+const TEAM_FEED: TeamFeedItem[] = [
+  // Session start
+  { type: "system", text: "session started · Opus 4.6 · 47 tools · 6 agents" },
+
+  // User dispatches work to the team
+  { type: "user", text: "Fix the JWT validation bug in auth.ts. The token expiry check is off by one hour.", target: "backend" },
+  { type: "user", text: "Run the test suite after backend finishes and report results.", target: "qa" },
+  { type: "user", text: "Update the API docs once the fix lands.", target: "docs" },
+
+  // Agents start working — status transitions
+  { type: "status", agent: "backend", from: "idle", to: "running" },
+  { type: "status", agent: "qa", from: "idle", to: "waiting" },
+  { type: "status", agent: "docs", from: "idle", to: "running" },
+
+  // Backend finishes first turn — SUMMARY (not the full verbose output)
+  {
+    type: "summary",
+    agent: "backend",
+    summary: "Fixed JWT validation — converted Date.now() to seconds, added 30s clock skew tolerance, updated error logging in validateToken()",
+    cost: 0.08,
+    turns: 5,
+    duration: "2m 10s",
+  },
+
+  // Backend asks a question
+  {
+    type: "question",
+    agent: "backend",
+    question: "Should I also add refresh token rotation while I'm in auth.ts?",
+    options: ["Yes, add rotation", "No, just the fix", "Create a separate task for it"],
+  },
+
+  // User responds
+  { type: "user", text: "Yes, add rotation. Good catch." },
+
+  // QA picks up after backend
+  { type: "status", agent: "qa", from: "waiting", to: "running" },
+
+  // Backend finishes second turn
+  {
+    type: "summary",
+    agent: "backend",
+    summary: "Added refresh token rotation — tokens now rotate on each refresh, old tokens invalidated after 60s grace period. Updated 3 test fixtures.",
+    cost: 0.04,
+    turns: 3,
+    duration: "1m 12s",
+  },
+
+  // QA reports failure
+  {
+    type: "error",
+    agent: "qa",
+    text: "2 assertions failed in auth.test.ts:\n  - Expected 200 on /api/refresh, got 401\n  - Token rotation test expects old format",
+  },
+  { type: "status", agent: "qa", from: "running", to: "error" },
+
+  // User directs backend to fix
+  { type: "user", text: "@backend the refresh endpoint still rejects — check the middleware order", target: "backend" },
+
+  // Backend fixes it
+  {
+    type: "summary",
+    agent: "backend",
+    summary: "Fixed middleware ordering — auth middleware now runs after token refresh handler. Updated test fixtures to match new rotation format.",
+    cost: 0.04,
+    turns: 3,
+    duration: "1m 00s",
+  },
+
+  // QA reruns and passes
+  { type: "status", agent: "qa", from: "error", to: "running" },
+  {
+    type: "summary",
+    agent: "qa",
+    summary: "All 47 tests passing. Auth suite: 12/12 pass. Refresh rotation: 3/3 pass. No regressions detected.",
+    cost: 0.05,
+    turns: 5,
+    duration: "2m 10s",
+  },
+
+  // Docs finishes
+  {
+    type: "summary",
+    agent: "docs",
+    summary: "Updated API reference — added refresh token rotation docs, updated auth flow diagram, added migration notes for v2 token format.",
+    cost: 0.02,
+    turns: 2,
+    duration: "1m 30s",
+  },
+  { type: "status", agent: "docs", from: "running", to: "stopped" },
+
+  // Session summary
+  { type: "system", text: "3 agents completed · 18 turns · $0.23 total" },
+]
+
+/* ================================================================== */
 /*  STATUS CONFIG                                                      */
 /* ================================================================== */
 
@@ -157,11 +295,14 @@ const STATUS_CONFIG: Record<
   waiting: { dot: "bg-warning", label: "Waiting", text: "text-warning" },
   error: { dot: "bg-danger", label: "Error", text: "text-danger" },
   stopped: { dot: "bg-muted/50", label: "Stopped", text: "text-muted" },
+  deploying: { dot: "bg-accent", label: "Starting", text: "text-accent" },
 }
 
 const PILL_CONFIG = [
   { key: "error" as const, dot: "bg-danger", text: "text-danger" },
+  { key: "waiting" as const, dot: "bg-warning", text: "text-warning" },
   { key: "running" as const, dot: "bg-success", text: "text-success", animate: true },
+  { key: "deploying" as const, dot: "bg-accent", text: "text-accent" },
   { key: "idle" as const, dot: "bg-info", text: "text-muted" },
   { key: "stopped" as const, dot: "bg-muted/40", text: "text-muted/50" },
 ]
@@ -185,8 +326,16 @@ function useBreakpoint(): Breakpoint {
       else setBp("XL")
     }
     calc()
-    window.addEventListener("resize", calc)
-    return () => window.removeEventListener("resize", calc)
+    let raf: number
+    function onResize() {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(calc)
+    }
+    window.addEventListener("resize", onResize)
+    return () => {
+      window.removeEventListener("resize", onResize)
+      cancelAnimationFrame(raf)
+    }
   }, [])
 
   return bp
@@ -242,22 +391,7 @@ function ChatAvatar({ name }: { name: string }) {
 /*  FEED CONTENT COMPONENTS                                            */
 /* ================================================================== */
 
-/** 1. User message — right-aligned bubble */
-function UserMessage({ text }: { text: string }) {
-  return (
-    <div className="flex justify-end py-1">
-      <div className="max-w-[80%]">
-        <div className="bg-accent/15 border border-accent/20 rounded px-3 py-1.5">
-          <p className="text-default text-sm whitespace-pre-wrap leading-relaxed">
-            {text}
-          </p>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/** 2. Assistant message with markdown — left-aligned with avatar */
+/** 2. Assistant message with markdown — left-aligned with avatar (used in agent detail feed) */
 function AssistantMessage({
   agent,
   content,
@@ -285,6 +419,11 @@ function AssistantMessage({
           className="text-sm text-default"
         />
       </div>
+      {content.length > 0 && (
+        <div className="absolute top-0 right-0 opacity-0 group-hover/msg:opacity-100 transition-opacity">
+          <CopyButton text={content} />
+        </div>
+      )}
     </div>
   )
 }
@@ -305,6 +444,7 @@ function SingleToolRow({
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
           className="flex items-center gap-2 w-full text-left px-2.5 py-1 cursor-pointer hover:bg-surface-sunken/40 transition-colors"
         >
           <ChevronRight
@@ -360,6 +500,7 @@ function MultiToolGroup({
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
           className="flex items-center gap-2 w-full text-left px-2.5 py-1 cursor-pointer hover:bg-surface-sunken/40 transition-colors"
         >
           <ChevronRight
@@ -396,6 +537,7 @@ function ToolRow({ toolName, summary }: { toolName: string; summary: string }) {
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
         className="flex items-center gap-2 w-full text-left px-2.5 py-0.5 cursor-pointer hover:bg-surface-sunken/40 transition-colors"
       >
         <ChevronRight
@@ -447,6 +589,7 @@ function ResultPill({
         type="button"
         className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-mono cursor-pointer hover:bg-surface-sunken/40 transition-colors"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
       >
         {isError ? (
           <X size={12} className="shrink-0 text-danger" strokeWidth={2.5} />
@@ -628,34 +771,7 @@ function TodoList({
   )
 }
 
-/** 9. Activity summary line — inline collapsed */
-function ActivitySummary({
-  agent,
-  text,
-  tools,
-}: {
-  agent: string
-  text: string
-  tools: number
-}) {
-  return (
-    <div className="ml-8">
-      <div className="inline-flex items-center gap-2 border-l-2 border-l-muted/40 rounded-r px-2.5 py-1 hover:bg-surface-sunken/40 transition-colors cursor-pointer">
-        <ChevronRight size={12} className="shrink-0 text-muted" />
-        <AgentAvatar name={agent} size="sm" />
-        <span className="text-xs text-secondary font-medium">{agent}</span>
-        <span className="text-xs text-muted font-mono truncate">{text}</span>
-        {tools > 0 && (
-          <span className="text-[10px] text-muted/60 font-mono shrink-0">
-            (+{tools} tools)
-          </span>
-        )}
-      </div>
-    </div>
-  )
-}
-
-/** 10. Thinking indicator — pulsing dots */
+/** 10. Thinking indicator — pulsing dots (used in agent detail feed only) */
 function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
   return (
     <span className="inline-flex items-center gap-1.5 text-muted text-[11px] font-mono">
@@ -666,6 +782,146 @@ function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
       </span>
       <span>{label}</span>
     </span>
+  )
+}
+
+/* ================================================================== */
+/*  TEAM FEED COMPONENTS — main feed (summaries, not verbose)          */
+/*                                                                     */
+/*  These render team-level events. No tool calls, no thinking, no     */
+/*  intermediate messages. Those live in the right panel detail view.  */
+/* ================================================================== */
+
+/**
+ * Agent summary card — the primary content type in the team feed.
+ * SOURCE: TimelineEntry.summary field (populated when agent completes a turn)
+ * Shows: agent avatar, summary text, cost/turns/duration badge
+ */
+function AgentSummaryCard({
+  agent,
+  summary,
+  cost,
+  turns,
+  duration,
+  isError = false,
+}: {
+  agent: string
+  summary: string
+  cost: number
+  turns: number
+  duration: string
+  isError?: boolean
+}) {
+  return (
+    <div className="flex gap-2.5 min-w-0">
+      <ChatAvatar name={agent} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-[11px] text-muted font-mono">{agent}</span>
+          <span className="text-[9px] text-muted/40">&middot;</span>
+          <span className="text-[9px] text-muted/50 font-mono tabular-nums">
+            {turns} turn{turns !== 1 ? "s" : ""} · {duration} · {formatCost(cost)}
+          </span>
+        </div>
+        <div
+          className={cn(
+            "rounded-lg border px-3 py-2",
+            isError
+              ? "border-danger/20 bg-danger-subtle/20"
+              : "border-border-subtle bg-surface-raised/40",
+          )}
+        >
+          <p className={cn(
+            "text-sm leading-relaxed",
+            isError ? "text-danger" : "text-default",
+          )}>
+            {summary}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Status transition line — inline status change notification.
+ * SOURCE: StreamEvent status change (agent.status field transitions)
+ */
+function AgentStatusLine({ agent, from, to }: { agent: string; from: string; to: string }) {
+  const toConfig = STATUS_CONFIG[to] ?? STATUS_CONFIG.stopped
+
+  return (
+    <div className="flex items-center justify-center gap-2 py-0.5">
+      <AgentAvatar name={agent} size="sm" />
+      <span className="text-[10px] text-muted font-mono">
+        {agent}
+      </span>
+      <span className="text-[10px] text-muted/40 font-mono">{from}</span>
+      <span className="text-[10px] text-muted/30">→</span>
+      <span className={cn("text-[10px] font-mono font-medium", toConfig.text)}>
+        {to}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Team user message — right-aligned with optional @target indicator.
+ * SOURCE: user input via composer (with optional @agent targeting)
+ */
+function TeamUserMessage({ text, target }: { text: string; target?: string }) {
+  return (
+    <div className="flex justify-end py-1">
+      <div className="max-w-[80%]">
+        {target && (
+          <div className="flex justify-end mb-0.5">
+            <span className="text-[10px] text-accent font-mono">@{target}</span>
+          </div>
+        )}
+        <div className="bg-accent/15 border border-accent/20 rounded px-3 py-1.5">
+          <p className="text-default text-sm whitespace-pre-wrap leading-relaxed">
+            {text}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Team error alert — prominent error from an agent.
+ * SOURCE: StreamEvent with isError flag, or TimelineEntry.summary with error content
+ */
+function TeamErrorAlert({ agent, text }: { agent: string; text: string }) {
+  return (
+    <div className="flex gap-2.5 min-w-0">
+      <div className="shrink-0 w-6 h-6 rounded-full flex items-center justify-center bg-danger-subtle mt-1">
+        <AlertCircle className="h-3.5 w-3.5 text-danger" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-danger font-mono mb-0.5">{agent}</div>
+        <div className="rounded-lg border border-danger/20 bg-danger-subtle/20 px-3 py-2">
+          <p className="text-xs text-danger leading-relaxed font-mono whitespace-pre-wrap">
+            {text}
+          </p>
+          <div className="flex items-center gap-2 mt-2">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-danger/30 text-[11px] text-danger font-medium hover:bg-danger-subtle/60 transition-colors"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Retry
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] text-muted font-medium hover:text-secondary transition-colors"
+            >
+              View details →
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -691,7 +947,7 @@ function SecretsModal({
 
   if (!open) return null
 
-  const activeAgents = agents.filter((a) => a.status === "running" || a.status === "idle")
+  const activeAgents = agents.filter((a) => a.status === "running" || a.status === "idle" || a.status === "deploying")
   const needsRestart = dirty && !restarted
 
   const toggleReveal = (id: string) => {
@@ -731,21 +987,30 @@ function SecretsModal({
   }
 
   return (
-    <div className="fixed inset-0 z-(--z-overlay) flex items-center justify-center">
+    <div
+      className="fixed inset-0 z-(--z-overlay) flex items-center justify-center"
+      onKeyDown={(e) => { if (e.key === "Escape") onClose() }}
+    >
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-surface-backdrop backdrop-blur-sm"
         onClick={onClose}
       />
 
       {/* Modal */}
-      <div className="relative w-full max-w-lg mx-4 rounded-xl border border-border-default bg-surface-raised shadow-lg overflow-hidden">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="secrets-title"
+        tabIndex={-1}
+        className="relative w-full max-w-lg mx-4 rounded-xl border border-border-default bg-surface-raised shadow-lg overflow-hidden"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-5 pb-3">
           <div>
             <div className="flex items-center gap-2">
               <KeyRound className="h-4 w-4 text-muted" />
-              <h2 className="text-sm font-semibold text-default">Project Secrets</h2>
+              <h2 id="secrets-title" className="text-sm font-semibold text-default">Project Secrets</h2>
             </div>
             <p className="text-[11px] text-muted mt-0.5 ml-6">
               Environment variables injected into agent containers
@@ -790,7 +1055,7 @@ function SecretsModal({
                   </span>
 
                   {/* Actions */}
-                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                     <button
                       type="button"
                       onClick={() => toggleReveal(secret.id)}
@@ -933,11 +1198,9 @@ function HeaderBar({
             <span
               className={cn(
                 "h-1.5 w-1.5 rounded-full shrink-0",
-                selectedAgent.status === "running" && "bg-success animate-breathe text-success",
-                selectedAgent.status === "error" && "bg-danger",
-                selectedAgent.status === "idle" && "bg-info",
-                selectedAgent.status === "stopped" && "bg-muted/50",
-                selectedAgent.status === "waiting" && "bg-warning",
+                (STATUS_CONFIG[selectedAgent.status] ?? STATUS_CONFIG.stopped).dot,
+                selectedAgent.status === "running" && "animate-breathe",
+                (STATUS_CONFIG[selectedAgent.status] ?? STATUS_CONFIG.stopped).glow,
               )}
             />
             <span className="font-medium text-default">{selectedAgent.name}</span>
@@ -970,49 +1233,21 @@ function HeaderBar({
 }
 
 /* ================================================================== */
-/*  SESSION INFO BAR                                                   */
-/* ================================================================== */
-
-function SessionInfoBar({ agent }: { agent: FakeAgent | null }) {
-  if (!agent) return null
-
-  const items = [
-    agent.model,
-    "47 tools",
-    formatCost(agent.cost),
-    `${agent.turns} turn${agent.turns === 1 ? "" : "s"}`,
-    "default",
-    agent.phase,
-  ].filter(Boolean)
-
-  return (
-    <div className="h-8 border-b border-border-default bg-surface px-4 flex items-center gap-2 shrink-0">
-      {items.map((item, i) => (
-        <span key={i} className="text-xs text-muted flex items-center gap-2">
-          {i > 0 && <span className="text-muted">&middot;</span>}
-          <span className="font-mono">{item}</span>
-        </span>
-      ))}
-    </div>
-  )
-}
-
-/* ================================================================== */
 /*  COMPOSER BAR                                                       */
 /* ================================================================== */
 
-function ComposerBar({ selectedAgent }: { selectedAgent: FakeAgent | null }) {
-  const placeholder = selectedAgent
-    ? `Message ${selectedAgent.name}...`
-    : "Message team lead... (type @ to target)"
-
+/**
+ * Composer bar — main feed message input.
+ * Broadcasts to all agents by default, use @agent to target one.
+ * Individual agent messaging happens in the right panel's mini-composer.
+ */
+function ComposerBar() {
   return (
     <div className="px-6 pb-4 pt-2 max-w-3xl mx-auto w-full shrink-0">
-      <div className="relative rounded-2xl border-[0.5px] border-border-default bg-surface-raised/60">
+      <div className="relative rounded-2xl border-[0.5px] border-border-default bg-surface-raised/60 focus-within:bg-surface-raised focus-within:border-border-default">
         {/* Text input */}
         <textarea
-          readOnly
-          placeholder={placeholder}
+          placeholder="Message your team... (type @ to target an agent)"
           rows={1}
           className="w-full bg-transparent border-none outline-none resize-none px-4 pt-4 pb-2 text-sm text-default placeholder:text-muted min-h-[52px] max-h-[40vh]"
         />
@@ -1029,25 +1264,14 @@ function ComposerBar({ selectedAgent }: { selectedAgent: FakeAgent | null }) {
               <Plus className="h-4 w-4" />
             </button>
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium text-muted">
-              <Code className="h-3 w-3" />
-              Normal
+              <Users className="h-3 w-3" />
+              All agents
             </span>
-            {selectedAgent && (
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-surface-sunken text-xs text-secondary font-medium">
-                <span
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full",
-                    selectedAgent.status === "running" ? "bg-success" : selectedAgent.status === "idle" ? "bg-info" : "bg-muted",
-                  )}
-                />
-                {selectedAgent.name}
-              </span>
-            )}
           </div>
 
           {/* Right side */}
           <div className="flex items-center gap-3">
-            <span className="text-xs text-muted tabular-nums">$0.30</span>
+            <span className="text-xs text-muted font-mono tabular-nums">$0.30</span>
             <button
               type="button"
               className="flex items-center justify-center h-8 w-8 rounded-full bg-surface-sunken text-muted cursor-not-allowed"
@@ -1062,112 +1286,57 @@ function ComposerBar({ selectedAgent }: { selectedAgent: FakeAgent | null }) {
 }
 
 /* ================================================================== */
-/*  CHAT FEED                                                          */
+/*  TEAM FEED — main feed renders team-level events only               */
+/*                                                                     */
+/*  This is the "slack channel" view. You see:                         */
+/*  - Your messages to agents (@mentions + broadcasts)                 */
+/*  - Agent summaries when they complete a turn                        */
+/*  - Status transitions (started, errored, stopped)                   */
+/*  - Error alerts (actionable)                                        */
+/*  - AskUserQuestion cards (agent needs input)                        */
+/*  - System messages (session lifecycle)                               */
+/*                                                                     */
+/*  You do NOT see: tool calls, thinking, intermediate assistant        */
+/*  messages, tool results. Those live in the right panel detail view. */
 /* ================================================================== */
 
-function ChatFeed({ selectedAgent }: { selectedAgent: FakeAgent | null }) {
+function TeamFeed() {
   return (
     <div className="flex flex-col h-full min-w-0">
-      <SessionInfoBar agent={selectedAgent} />
-
       <ScrollArea className="flex-1 overflow-y-auto dotted-grid">
         <div className="max-w-3xl mx-auto w-full px-6 py-4 space-y-3">
-          {/* 6. System init message */}
-          <SystemMessage text="Opus 4.6 · 47 tools" />
-          <SystemMessage text="session initialized" />
-
-          {/* 1. User message */}
-          <UserMessage text="Fix the JWT validation bug in auth.ts. The token expiry check is off by one hour." />
-
-          {/* 2. Assistant message with markdown */}
-          <AssistantMessage
-            agent="backend"
-            content={FAKE_MARKDOWN}
-          />
-
-          {/* 3. Single tool call */}
-          <SingleToolRow toolName="Read" summary="src/auth.ts" />
-
-          {/* 9. Activity summary */}
-          <ActivitySummary
-            agent="frontend"
-            text="Reading component styles"
-            tools={2}
-          />
-
-          {/* 2b. Assistant follow-up (no avatar — same agent) */}
-          <AssistantMessage
-            agent="backend"
-            content="I've applied the fix. Let me also run the linter and verify the tests pass."
-            showAvatar={false}
-          />
-
-          {/* 3b. Multi-tool group */}
-          <MultiToolGroup
-            tools={[
-              { name: "Edit", summary: "src/auth.ts" },
-              { name: "Bash", summary: "npm run lint" },
-              { name: "Bash", summary: "npm test -- --filter auth" },
-            ]}
-          />
-
-          {/* 7. AskUserQuestion card */}
-          <QuestionCard
-            agent="backend"
-            question="The fix is ready. How should I handle the clock skew tolerance?"
-            options={[
-              "30 seconds (Recommended)",
-              "60 seconds",
-              "No tolerance",
-              "Configurable via env var",
-            ]}
-          />
-
-          {/* 1b. User reply */}
-          <UserMessage text="Go with 30 seconds. That's the standard." />
-
-          {/* 5. Error bubble */}
-          <ErrorBubble
-            agent="qa"
-            text={"npm test failed: FAIL src/auth.test.ts\n\nExpected: 200\nReceived: 401\n\nThe auth.ts fix hasn't landed in the test environment yet."}
-          />
-
-          {/* 10. Thinking indicator */}
-          <div className="flex gap-2 min-w-0">
-            <ChatAvatar name="backend" />
-            <div className="min-w-0 flex-1">
-              <div className="text-[11px] text-muted font-mono mb-0.5">backend</div>
-              <ThinkingIndicator label="Applying clock skew fix..." />
-            </div>
-          </div>
-
-          {/* 4. Result pill */}
-          <ResultPill
-            cost={0.12}
-            duration="3m 22s"
-            turns={8}
-            model="Opus 4.6"
-          />
-
-          {/* 8. Todo list */}
-          <TodoList
-            agent="backend"
-            tasks={[
-              { text: "Read auth.ts and identify the bug", done: true },
-              { text: "Fix Date.now() → seconds conversion", done: true },
-              { text: "Add 30s clock skew tolerance", done: true },
-              { text: "Run linter", done: true },
-              { text: "Run auth test suite", done: false },
-              { text: "Update error logging", done: false },
-            ]}
-          />
-
-          {/* 6b. Status message */}
-          <SystemMessage text="backend session complete · 8 turns · $0.12" />
+          {TEAM_FEED.map((item, i) => {
+            switch (item.type) {
+              case "system":
+                return <SystemMessage key={i} text={item.text} />
+              case "user":
+                return <TeamUserMessage key={i} text={item.text} target={item.target} />
+              case "summary":
+                return (
+                  <AgentSummaryCard
+                    key={i}
+                    agent={item.agent}
+                    summary={item.summary}
+                    cost={item.cost}
+                    turns={item.turns}
+                    duration={item.duration}
+                    isError={item.isError}
+                  />
+                )
+              case "status":
+                return <AgentStatusLine key={i} agent={item.agent} from={item.from} to={item.to} />
+              case "error":
+                return <TeamErrorAlert key={i} agent={item.agent} text={item.text} />
+              case "question":
+                return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
+              default:
+                return null
+            }
+          })}
         </div>
       </ScrollArea>
 
-      <ComposerBar selectedAgent={selectedAgent} />
+      <ComposerBar />
     </div>
   )
 }
@@ -1190,7 +1359,7 @@ function RosterPanel({
   onSelectAgent: (id: string | null) => void
 }) {
   const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0 }
+    const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
     for (const a of agents) counts[a.status] = (counts[a.status] ?? 0) + 1
     return counts
   }, [agents])
@@ -1473,7 +1642,20 @@ function VncThumbnail({ agent }: { agent: FakeAgent }) {
   )
 }
 
-/** Unified agent card: info + VNC preview side by side */
+/**
+ * Agent card with two states:
+ *
+ * COLLAPSED — compact single row:
+ *   avatar | name | status dot | live action one-liner | cost · time
+ *   SOURCE: Agent model fields + latest tool_use content block (liveAction)
+ *
+ * EXPANDED — full card with VNC + detail feed:
+ *   Top: agent info grid (left) + VNC thumbnail (right)
+ *   Bottom: scrollable detail feed of verbose output
+ *   SOURCE: TimelineEntry.content (full content blocks)
+ *
+ * Click toggles between states (onSelect handler does the toggle).
+ */
 function AgentCardRow({
   agent,
   isSelected,
@@ -1490,76 +1672,283 @@ function AgentCardRow({
   const isError = agent.status === "error"
   const isStopped = agent.status === "stopped"
 
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={cn(
-        "w-full text-left rounded-lg border transition-all duration-(--duration-normal)",
-        isSelected
-          ? "border-accent/40 bg-surface-raised/80 shadow-sm"
-          : "border-border-subtle bg-surface hover:bg-surface-raised/40 hover:border-border-default",
-        isError && "border-danger/30",
-        isStopped && "opacity-60",
-      )}
-    >
-      <div className={cn("grid gap-2", compact ? "grid-cols-1 p-2.5" : "grid-cols-2 p-3")}>
-        {/* Left: agent info */}
-        <div className="min-w-0 flex flex-col">
-          {/* Header: avatar + name + status */}
-          <div className="flex items-center gap-2 mb-1.5">
-            <AgentAvatar name={agent.name} stopped={isStopped} />
-            <span
-              className={cn(
-                "text-[13px] font-medium flex-1 truncate",
-                isStopped ? "text-muted" : "text-default",
-              )}
-            >
-              {agent.name}
-            </span>
-            <span
-              className={cn(
-                "h-2 w-2 rounded-full shrink-0",
-                config.dot,
-                isRunning && "animate-breathe text-success",
-              )}
-            />
-          </div>
+  /* ---- COLLAPSED: compact single-row card ---- */
+  if (!isSelected) {
+    return (
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          "w-full text-left rounded-lg border px-2.5 py-2 transition-all duration-(--duration-normal)",
+          "border-border-subtle bg-surface hover:bg-surface-raised/40 hover:border-border-default",
+          isError && "border-danger/30 hover:border-danger/40",
+          isStopped && "opacity-60",
+        )}
+      >
+        {/* Row 1: avatar + name + status dot + live action + cost/time */}
+        <div className="flex items-center gap-2 min-w-0">
+          <AgentAvatar name={agent.name} size="sm" stopped={isStopped} />
+          <span
+            className={cn(
+              "text-[12px] font-medium shrink-0",
+              isStopped ? "text-muted" : "text-default",
+            )}
+          >
+            {agent.name}
+          </span>
+          <span
+            className={cn(
+              "h-1.5 w-1.5 rounded-full shrink-0",
+              config.dot,
+              isRunning && "animate-breathe text-success",
+            )}
+          />
 
-          {/* Current task */}
-          <div className="flex items-start gap-1.5 mb-1">
-            <Terminal className="h-3 w-3 text-muted/60 shrink-0 mt-0.5" />
-            <span className="text-[11px] text-secondary leading-tight truncate">
+          {/* Live action one-liner — the continuously updating current action
+              SOURCE: latest tool_use content block name + input summary */}
+          {agent.liveAction ? (
+            <span className="text-[10px] text-muted font-mono truncate flex-1 min-w-0">
+              {agent.liveAction}
+            </span>
+          ) : (
+            <span className="text-[10px] text-muted/50 font-mono truncate flex-1 min-w-0">
               {agent.task}
             </span>
-          </div>
+          )}
 
-          {/* Last output */}
-          <div className="rounded bg-surface-sunken/60 px-1.5 py-1 mb-1.5 flex-1">
-            <p className="text-[10px] text-muted font-mono leading-relaxed line-clamp-2 whitespace-pre-wrap">
-              {agent.lastOutput}
-            </p>
-          </div>
-
-          {/* Stats row */}
-          <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap">
-            <span className="inline-flex items-center gap-0.5">
-              <DollarSign className="h-2.5 w-2.5" />
-              {formatCost(agent.cost)}
-            </span>
-            <span className="inline-flex items-center gap-0.5">
-              <Clock className="h-2.5 w-2.5" />
-              {agent.duration}
-            </span>
-            <span className="text-muted/50">&middot;</span>
-            <span>{agent.model}</span>
-          </div>
+          {/* Right: cost · time */}
+          <span className="text-[9px] text-muted/60 font-mono tabular-nums shrink-0">
+            {formatCost(agent.cost)} · {agent.duration}
+          </span>
         </div>
+      </button>
+    )
+  }
 
-        {/* Right: VNC thumbnail */}
-        <VncThumbnail agent={agent} />
+  /* ---- EXPANDED: full card with VNC + detail feed ---- */
+  return (
+    <div
+      className={cn(
+        "rounded-lg border transition-all duration-(--duration-normal)",
+        "border-accent/40 bg-surface-raised/80 shadow-sm",
+        isError && "border-danger/40",
+      )}
+    >
+      {/* Clickable header — click to collapse */}
+      <button
+        type="button"
+        onClick={onSelect}
+        className="w-full text-left"
+      >
+        <div className={cn("grid gap-2", compact ? "grid-cols-1 p-2.5" : "grid-cols-2 p-3")}>
+          {/* Left: agent info */}
+          <div className="min-w-0 flex flex-col">
+            {/* Header: avatar + name + status */}
+            <div className="flex items-center gap-2 mb-1.5">
+              <AgentAvatar name={agent.name} stopped={isStopped} />
+              <span className="text-[13px] font-medium flex-1 truncate text-default">
+                {agent.name}
+              </span>
+              <ChevronRight
+                size={14}
+                className="shrink-0 text-muted rotate-90 transition-transform"
+              />
+              <span
+                className={cn(
+                  "h-2 w-2 rounded-full shrink-0",
+                  config.dot,
+                  isRunning && "animate-breathe text-success",
+                )}
+              />
+            </div>
+
+            {/* Current task */}
+            <div className="flex items-start gap-1.5 mb-1">
+              <Terminal className="h-3 w-3 text-muted/60 shrink-0 mt-0.5" />
+              <span className="text-[11px] text-secondary leading-tight truncate">
+                {agent.task}
+              </span>
+            </div>
+
+            {/* Stats row */}
+            <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap">
+              <span className="inline-flex items-center gap-0.5">
+                <DollarSign className="h-2.5 w-2.5" />
+                {formatCost(agent.cost)}
+              </span>
+              <span className="inline-flex items-center gap-0.5">
+                <Clock className="h-2.5 w-2.5" />
+                {agent.duration}
+              </span>
+              <span className="text-muted/50">&middot;</span>
+              <span>{agent.model}</span>
+              <span className="text-muted/50">&middot;</span>
+              <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
+            </div>
+          </div>
+
+          {/* Right: VNC thumbnail */}
+          <VncThumbnail agent={agent} />
+        </div>
+      </button>
+
+      {/* Expanded detail feed — full verbose output from TimelineEntry.content */}
+      <AgentDetailFeed agent={agent} />
+    </div>
+  )
+}
+
+/**
+ * Agent detail mini-feed — shows VERBOSE output for a single agent.
+ * This is the drill-in view. Content comes from TimelineEntry.content
+ * (full content blocks), NOT from the summary field.
+ *
+ * SOURCE: TimelineEntry.content — tool_use blocks, assistant text,
+ *   thinking blocks, tool_result blocks. Everything the team feed hides.
+ */
+function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
+  const isRunning = agent.status === "running"
+  const isError = agent.status === "error"
+
+  return (
+    <div className="border-t border-border-subtle">
+      {/* Mini-feed header */}
+      <div className="px-3 py-1.5 flex items-center gap-2 bg-surface-sunken/30">
+        <MessageSquare className="h-3 w-3 text-muted/60" />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted/60">
+          Detail Feed
+        </span>
+        <span className="text-[9px] text-muted/40 font-mono">
+          source: content blocks
+        </span>
       </div>
-    </button>
+
+      {/* Verbose content — scrollable mini-feed */}
+      <div className="max-h-[320px] overflow-y-auto px-3 py-2 space-y-2">
+        {/* Show different content based on agent */}
+        {agent.name === "backend" ? (
+          <>
+            {/* Thinking indicator (source: thinking content block) */}
+            <ThinkingIndicator label="Analyzing auth.ts..." />
+
+            {/* Tool calls (source: tool_use content blocks) */}
+            <SingleToolRow toolName="Read" summary="src/auth.ts" />
+            <SingleToolRow toolName="Read" summary="src/middleware/auth.ts" />
+
+            {/* Assistant message (source: text content blocks) */}
+            <AssistantMessage
+              agent={agent.name}
+              content={FAKE_MARKDOWN}
+              showAvatar={false}
+            />
+
+            {/* More tool calls */}
+            <MultiToolGroup
+              tools={[
+                { name: "Edit", summary: "src/auth.ts — fix validateToken()" },
+                { name: "Edit", summary: "src/middleware/auth.ts — reorder handlers" },
+                { name: "Bash", summary: "npm run lint" },
+              ]}
+            />
+
+            <AssistantMessage
+              agent={agent.name}
+              content="Applied the fix and ran the linter. All clean."
+              showAvatar={false}
+            />
+
+            {/* Result pill (source: result message) */}
+            <ResultPill cost={agent.cost} duration={agent.duration} turns={agent.turns} model={agent.model} />
+
+            {/* Todo list (source: TodoWrite tool_use blocks) */}
+            {isRunning && (
+              <TodoList
+                agent={agent.name}
+                tasks={[
+                  { text: "Read auth.ts and identify the bug", done: true },
+                  { text: "Fix Date.now() → seconds conversion", done: true },
+                  { text: "Add 30s clock skew tolerance", done: true },
+                  { text: "Add refresh token rotation", done: true },
+                  { text: "Run linter", done: true },
+                  { text: "Update test fixtures", done: false },
+                ]}
+              />
+            )}
+          </>
+        ) : agent.name === "qa" ? (
+          <>
+            <SingleToolRow toolName="Bash" summary="npm test -- --filter auth" />
+            {isError ? (
+              <ErrorBubble
+                agent={agent.name}
+                text={"FAIL src/auth.test.ts\n\nExpected: 200\nReceived: 401\n\nThe refresh endpoint middleware ordering is wrong."}
+              />
+            ) : (
+              <>
+                <AssistantMessage
+                  agent={agent.name}
+                  content="Running the full auth test suite. 47 tests found."
+                  showAvatar={false}
+                />
+                <ResultPill cost={agent.cost} duration={agent.duration} turns={agent.turns} model={agent.model} />
+              </>
+            )}
+          </>
+        ) : agent.name === "frontend" ? (
+          <>
+            <ThinkingIndicator label="Reading component styles..." />
+            <SingleToolRow toolName="Read" summary="src/components/Button.tsx" />
+            <SingleToolRow toolName="Read" summary="src/styles/tokens.css" />
+            <AssistantMessage
+              agent={agent.name}
+              content="Scanning Tailwind classes in Button, Card, and Input components..."
+              showAvatar={false}
+            />
+          </>
+        ) : agent.name === "docs" ? (
+          <>
+            <SingleToolRow toolName="Read" summary="docs/api-reference.md" />
+            <MultiToolGroup
+              tools={[
+                { name: "Edit", summary: "docs/api-reference.md — add rotation docs" },
+                { name: "Edit", summary: "docs/auth-flow.md — update diagram" },
+              ]}
+            />
+            <AssistantMessage
+              agent={agent.name}
+              content="Updated API reference with refresh token rotation documentation and migration notes."
+              showAvatar={false}
+            />
+            <ResultPill cost={agent.cost} duration={agent.duration} turns={agent.turns} model={agent.model} />
+          </>
+        ) : (
+          /* Generic fallback for devops, infra, etc. */
+          <div className="flex items-center justify-center py-4">
+            <span className="text-[10px] text-muted/50 font-mono">
+              {agent.status === "deploying" ? "Initializing workspace..." : "No activity yet"}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Mini composer — message this specific agent */}
+      <div className="px-3 py-2 border-t border-border-subtle">
+        <div className="flex items-center gap-2 rounded-lg border border-border-default bg-surface-sunken/40 px-2.5 py-1.5">
+          <span className="text-[10px] text-accent font-mono shrink-0">@{agent.name}</span>
+          <input
+            type="text"
+            placeholder="Message this agent..."
+            className="flex-1 bg-transparent border-none outline-none text-xs text-default placeholder:text-muted/40 min-w-0"
+          />
+          <button
+            type="button"
+            className="flex items-center justify-center h-5 w-5 rounded-full bg-surface text-muted"
+          >
+            <ArrowUp className="h-3 w-3" strokeWidth={2.5} />
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -1605,11 +1994,13 @@ function TabBar({
   onTabChange: (id: string) => void
 }) {
   return (
-    <div className="h-8 flex items-center gap-1 px-3 border-b border-border-default bg-surface shrink-0">
+    <div role="tablist" className="h-8 flex items-center gap-1 px-3 border-b border-border-default bg-surface shrink-0">
       {tabs.map((tab) => (
         <button
           key={tab.id}
           type="button"
+          role="tab"
+          aria-selected={activeTab === tab.id}
           onClick={() => onTabChange(tab.id)}
           className={cn(
             "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
@@ -1669,9 +2060,11 @@ function PanelHeader({ children }: { children: React.ReactNode }) {
 /** Drag handle for resizable panels. Place on the leading edge of the panel. */
 function ResizeHandle({
   onResize,
+  onReset,
   side = "left",
 }: {
   onResize: (delta: number) => void
+  onReset?: () => void
   side?: "left" | "right"
 }) {
   const dragging = useRef(false)
@@ -1702,11 +2095,17 @@ function ResizeHandle({
     dragging.current = false
   }, [])
 
+  const onPointerCancel = useCallback(() => {
+    dragging.current = false
+  }, [])
+
   return (
     <div
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onDoubleClick={onReset}
       className={cn(
         "absolute top-0 bottom-0 w-1 z-(--z-dropdown) cursor-col-resize group/resize",
         side === "left" ? "left-0" : "right-0",
@@ -1750,6 +2149,10 @@ export default function PrototypePage() {
     setSelectedAgentId(id)
   }, [])
 
+  const handleSelectAgentCard = useCallback((id: string) => {
+    setSelectedAgentId((prev) => (prev === id ? null : id))
+  }, [])
+
   // Determine what's visible at each breakpoint
   const showRoster = bp !== "mobile"
   const showRightPanel = bp === "XL" || bp === "L" || bp === "M"
@@ -1778,13 +2181,16 @@ export default function PrototypePage() {
   return (
     <div className="h-screen flex flex-col bg-surface overflow-hidden">
       {/* Header bar */}
-      <HeaderBar
+      <header>
+        <h1 className="sr-only">Agentobox Dashboard</h1>
+        <HeaderBar
         onToggleSidebar={() => setRosterCollapsed((c) => !c)}
         onOpenSecrets={() => setSecretsOpen(true)}
         selectedAgent={selectedAgent}
         agents={AGENTS}
         showSidebarToggle={showRoster}
       />
+      </header>
 
       {/* Secrets modal */}
       <SecretsModal
@@ -1806,20 +2212,22 @@ export default function PrototypePage() {
       <div className="flex-1 flex min-h-0 overflow-hidden">
         {/* Roster */}
         {showRoster && (
-          <RosterPanel
-            collapsed={rosterCollapsed || bp === "M"}
-            onToggle={() => setRosterCollapsed((c) => !c)}
-            agents={AGENTS}
-            selectedAgentId={selectedAgentId}
-            onSelectAgent={handleSelectAgent}
-          />
+          <aside>
+            <RosterPanel
+              collapsed={rosterCollapsed || bp === "M"}
+              onToggle={() => setRosterCollapsed((c) => !c)}
+              agents={AGENTS}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={handleSelectAgent}
+            />
+          </aside>
         )}
 
-        {/* Center: chat feed */}
+        {/* Center: team feed (summaries only — no verbose agent output) */}
         {(!showTopTabs || mainTab === "chat") && (
-          <div className="flex-1 min-w-0 flex flex-col">
-            <ChatFeed selectedAgent={selectedAgent} />
-          </div>
+          <main className="flex-1 min-w-0 flex flex-col">
+            <TeamFeed />
+          </main>
         )}
 
         {/* Right panel: unified agent cards with inline VNC */}
@@ -1831,7 +2239,7 @@ export default function PrototypePage() {
               minWidth: effectiveRightWidth,
             }}
           >
-            <ResizeHandle onResize={handleRightPanelResize} side="left" />
+            <ResizeHandle onResize={handleRightPanelResize} onReset={() => setRightPanelWidth(null)} side="left" />
             <PanelHeader>
               <div className="flex items-center gap-2">
                 <Users className="h-3.5 w-3.5 text-muted" />
@@ -1843,7 +2251,7 @@ export default function PrototypePage() {
             <AgentCardsPanel
               agents={AGENTS}
               selectedAgentId={selectedAgentId}
-              onSelectAgent={(id) => setSelectedAgentId(id)}
+              onSelectAgent={handleSelectAgentCard}
               compact={compactCards}
             />
           </div>
@@ -1855,7 +2263,7 @@ export default function PrototypePage() {
             <AgentCardsPanel
               agents={AGENTS}
               selectedAgentId={selectedAgentId}
-              onSelectAgent={(id) => setSelectedAgentId(id)}
+              onSelectAgent={handleSelectAgentCard}
             />
           </div>
         )}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   ChevronRight,
   ChevronLeft,
+  ChevronDown,
   Check,
   X,
   AlertCircle,
@@ -391,6 +392,7 @@ type TeamFeedItem =
   | { type: "plan"; agent: string; title: string; plan: string; planStatus: "pending" | "approved" | "rejected" }
   | { type: "permission"; agent: string; command: string; risk?: string; permStatus: "pending" | "allowed" | "denied" }
   | { type: "multi-question"; agent: string; questions: { text: string; options: string[] }[] }
+  | { type: "agent-message"; from: string; to: string; text: string }
 
 const TEAM_FEED: TeamFeedItem[] = [
   // Session start
@@ -493,6 +495,9 @@ The JWT validation middleware rejects tokens within 5s of expiry due to \`Date.n
   },
   { type: "status", agent: "qa", from: "running", to: "error" },
 
+  // Backend pings QA about the fix
+  { type: "agent-message", from: "backend", to: "qa", text: "auth endpoints updated — refresh rotation uses new token format now, you may need to update fixtures" },
+
   // User directs backend to fix
   { type: "user", text: "@backend the refresh endpoint still rejects — check the middleware order", target: "backend" },
 
@@ -516,6 +521,9 @@ The JWT validation middleware rejects tokens within 5s of expiry due to \`Date.n
     turns: 5,
     duration: "2m 10s",
   },
+
+  // QA tells devops the branch is green
+  { type: "agent-message", from: "qa", to: "devops", text: "fix/jwt-validation is green — 47/47 tests pass, safe to deploy" },
 
   // QA requests permission to push
   {
@@ -1576,6 +1584,25 @@ function AgentStatusLine({ agent, from, to, onClickAgent }: { agent: string; fro
 }
 
 /**
+ * Agent-to-agent message — inline with arrow between two agent avatars.
+ * SOURCE: inter-agent @mention communication
+ */
+function AgentToAgentMessage({ from, to, text, onClickAgent }: { from: string; to: string; text: string; onClickAgent?: (name: string) => void }) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-0.5">
+      <button type="button" onClick={() => onClickAgent?.(from)} className="shrink-0 cursor-pointer">
+        <AgentAvatar name={from} size="sm" />
+      </button>
+      <span className="text-[10px] text-muted/30">→</span>
+      <button type="button" onClick={() => onClickAgent?.(to)} className="shrink-0 cursor-pointer">
+        <AgentAvatar name={to} size="sm" />
+      </button>
+      <span className="text-[10px] text-secondary font-mono truncate max-w-md">{text}</span>
+    </div>
+  )
+}
+
+/**
  * Team user message — right-aligned with optional @target indicator.
  * SOURCE: user input via composer (with optional @agent targeting)
  */
@@ -2610,108 +2637,6 @@ function ComposerBar({
 /*  PINNED ITEM CARD — shows pending plan/permission at feed top       */
 /* ================================================================== */
 
-type PlanFeedItem = Extract<TeamFeedItem, { type: "plan" }>
-
-function PinnedPlanContent({
-  item,
-  feedIndex,
-  onResolvePlan,
-}: {
-  item: PlanFeedItem
-  feedIndex: number
-  onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
-}) {
-  return (
-    <div>
-      {/* Header */}
-      <div className="px-3.5 pt-3 pb-1">
-        <div className="text-[11px] text-warning font-mono mb-1">{item.agent} · Proposing a plan</div>
-        <p className="text-[13px] font-medium text-default leading-snug">{item.title}</p>
-      </div>
-
-      {/* Plan markdown */}
-      <div className="border-t border-border-subtle/50 px-3.5 py-3">
-        <MarkdownRenderer
-          content={item.plan}
-          className="text-xs text-secondary [&_h2]:text-[11px] [&_h2]:font-mono [&_h2]:uppercase [&_h2]:tracking-wider [&_h2]:text-muted [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:first:mt-0 [&_ol]:space-y-1 [&_ul]:space-y-0.5 [&_li]:text-xs [&_li]:leading-relaxed [&_code]:text-[10px] [&_code]:bg-surface-sunken/60 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_p]:leading-relaxed [&_p]:mb-1.5"
-        />
-      </div>
-
-      {/* Actions */}
-      <div className="border-t border-border-subtle/50 px-3.5 py-2.5 flex items-center gap-2">
-        <button
-          type="button"
-          onClick={() => onResolvePlan(feedIndex, "approved")}
-          className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
-        >
-          Approve
-        </button>
-        <button
-          type="button"
-          onClick={() => onResolvePlan(feedIndex, "rejected")}
-          className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
-        >
-          Reject
-        </button>
-      </div>
-    </div>
-  )
-}
-
-function PinnedItemCard({
-  item,
-  feedIndex,
-  onResolvePermission,
-  onResolvePlan,
-}: {
-  item: PendingItem
-  feedIndex: number
-  onResolvePermission: (feedIndex: number, verdict: "allowed" | "denied") => void
-  onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
-}) {
-  return (
-    <div className="px-6 pt-3 pb-1 max-w-3xl mx-auto w-full shrink-0">
-      <div className="rounded-lg border border-warning/25 bg-warning-subtle/5 border-t-2 border-t-warning/40 overflow-hidden">
-        {item.type === "plan" ? (
-          <PinnedPlanContent item={item} feedIndex={feedIndex} onResolvePlan={onResolvePlan} />
-        ) : (
-          <div className="space-y-2">
-            <div className="text-[11px] text-info font-mono">
-              <Shield className="inline h-3 w-3 mr-1" />
-              {item.agent} · Requesting permission
-            </div>
-            <div className="rounded-md bg-surface-sunken/60 border border-border-subtle px-3 py-2">
-              <code className="text-xs font-mono text-default">{item.command}</code>
-            </div>
-            {item.risk && (
-              <div className="flex items-center gap-1.5">
-                <AlertTriangle className="h-3 w-3 text-warning shrink-0" />
-                <span className="text-[11px] text-warning">{item.risk}</span>
-              </div>
-            )}
-            <div className="flex items-center gap-2 pt-1">
-              <button
-                type="button"
-                onClick={() => onResolvePermission(feedIndex, "allowed")}
-                className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
-              >
-                Allow
-              </button>
-              <button
-                type="button"
-                onClick={() => onResolvePermission(feedIndex, "denied")}
-                className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
-              >
-                Deny
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
 /* ================================================================== */
 /*  ATTENTION BAR                                                      */
 /* ================================================================== */
@@ -2744,6 +2669,12 @@ function AttentionBar({
     }
   })
 
+  // Expanded plan review state
+  const [expandedFeedIndex, setExpandedFeedIndex] = useState<number | null>(null)
+  const expandedPlan = expandedFeedIndex !== null
+    ? pending.find(p => p.feedIndex === expandedFeedIndex && p.item.type === "plan")
+    : null
+
   if (pending.length === 0) return null
 
   // Sort: permissions first, then plans
@@ -2761,6 +2692,100 @@ function AttentionBar({
   const hasPrev = clamped > 0
   const hasNext = clamped < sorted.length - 1
 
+  const handleReview = (agentName: string, fi: number) => {
+    onReviewAgent(agentName)
+    setExpandedFeedIndex(fi)
+  }
+
+  const handleResolvePlanAndCollapse = (fi: number, verdict: "approved" | "rejected") => {
+    onResolvePlan(fi, verdict)
+    setExpandedFeedIndex(null)
+  }
+
+  // Expanded view — the card IS the attention bar
+  if (expandedPlan && expandedPlan.item.type === "plan") {
+    return (
+      <div className="px-6 mb-2 max-w-3xl mx-auto w-full">
+        <div className="rounded-lg border border-warning/20 bg-warning-subtle/10 overflow-hidden flex flex-col">
+          {/* Header: agent label + stepper + close */}
+          <div className="px-3.5 pt-3 pb-2 flex items-center gap-2">
+            <AlertTriangle className="h-3.5 w-3.5 text-warning shrink-0" />
+            <span className="text-[11px] text-warning font-mono">{expandedPlan.item.agent} · Proposing a plan</span>
+            <span className="flex-1" />
+            {sorted.length > 1 && (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  disabled={!hasPrev}
+                  onClick={() => { setStepIdx(clamped - 1); setExpandedFeedIndex(null) }}
+                  className={cn(
+                    "p-0.5 rounded transition-colors",
+                    hasPrev ? "text-secondary hover:text-default hover:bg-surface-raised/50" : "text-muted/30 cursor-default",
+                  )}
+                >
+                  <ChevronLeft className="h-3 w-3" />
+                </button>
+                <span className="text-[10px] text-muted tabular-nums font-mono">
+                  {clamped + 1}/{sorted.length}
+                </span>
+                <button
+                  type="button"
+                  disabled={!hasNext}
+                  onClick={() => { setStepIdx(clamped + 1); setExpandedFeedIndex(null) }}
+                  className={cn(
+                    "p-0.5 rounded transition-colors",
+                    hasNext ? "text-secondary hover:text-default hover:bg-surface-raised/50" : "text-muted/30 cursor-default",
+                  )}
+                >
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={() => setExpandedFeedIndex(null)}
+              className="p-0.5 rounded text-muted hover:text-default hover:bg-surface-raised/50 transition-colors"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+
+          {/* Title */}
+          <div className="px-3.5 pb-2">
+            <p className="text-[13px] font-medium text-default leading-snug">{expandedPlan.item.title}</p>
+          </div>
+
+          {/* Scrollable markdown body */}
+          <div className="border-t border-border-subtle/50 px-3.5 py-3 max-h-[35vh] overflow-y-auto">
+            <MarkdownRenderer
+              content={expandedPlan.item.plan}
+              className="text-xs text-secondary [&_h2]:text-[11px] [&_h2]:font-mono [&_h2]:uppercase [&_h2]:tracking-wider [&_h2]:text-muted [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:first:mt-0 [&_ol]:space-y-1 [&_ul]:space-y-0.5 [&_li]:text-xs [&_li]:leading-relaxed [&_code]:text-[10px] [&_code]:bg-surface-sunken/60 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_p]:leading-relaxed [&_p]:mb-1.5"
+            />
+          </div>
+
+          {/* Pinned footer — always visible */}
+          <div className="border-t border-border-subtle/50 px-3.5 py-2.5 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => handleResolvePlanAndCollapse(expandedPlan.feedIndex, "approved")}
+              className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={() => handleResolvePlanAndCollapse(expandedPlan.feedIndex, "rejected")}
+              className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Collapsed compact bar
   return (
     <div className="px-6 mb-2 max-w-3xl mx-auto w-full"><div className="rounded-lg border border-warning/20 bg-warning-subtle/10 p-3">
       {/* Header: icon + count + stepper nav */}
@@ -2832,7 +2857,7 @@ function AttentionBar({
           ) : (
             <button
               type="button"
-              onClick={() => onReviewAgent(item.agent)}
+              onClick={() => handleReview(item.agent, feedIndex)}
               className="px-2 py-1 rounded text-[10px] font-medium text-warning border border-warning/30 hover:bg-warning-subtle/40 transition-colors inline-flex items-center gap-1"
             >
               Review <ChevronRight className="h-2.5 w-2.5" />
@@ -2855,6 +2880,8 @@ function getFeedItemAgent(item: TeamFeedItem): string | null {
     case "permission":
     case "multi-question":
       return item.agent
+    case "agent-message":
+      return item.from // primary agent is sender; filtering handled separately
     case "user":
       return item.target ?? null
     case "system":
@@ -2898,6 +2925,8 @@ function TeamFeed({
         if (item.type === "user" && item.target && agentFilter.has(item.target)) return true
         // User messages without target pass through (broadcasts)
         if (item.type === "user" && !item.target) return true
+        // Agent-to-agent messages pass if either participant matches
+        if (item.type === "agent-message") return agentFilter.has(item.from) || agentFilter.has(item.to)
         // Agent items pass if agent matches
         return agent !== null && agentFilter.has(agent)
       })
@@ -2939,6 +2968,8 @@ function TeamFeed({
               return <PermissionCard key={i} agent={item.agent} command={item.command} risk={item.risk} permStatus={item.permStatus} />
             case "multi-question":
               return <MultiQuestionCard key={i} agent={item.agent} questions={item.questions} />
+            case "agent-message":
+              return <AgentToAgentMessage key={i} from={item.from} to={item.to} text={item.text} onClickAgent={onClickAgent} />
             default:
               return null
           }
@@ -4395,14 +4426,6 @@ export default function PrototypePage() {
     effectiveAgentFilter.size === 1 ? Array.from(effectiveAgentFilter)[0] : null
   , [effectiveAgentFilter])
 
-  const pinnedItem = useMemo(() => {
-    if (!singleFilteredAgent) return null
-    const pending = getPendingItemsForAgent(feedItems, singleFilteredAgent)
-    if (pending.length === 0) return null
-    const feedIndex = feedItems.indexOf(pending[0])
-    return { item: pending[0], feedIndex }
-  }, [singleFilteredAgent, feedItems])
-
   // Recipient handlers
   const defaultRecipient: RecipientEntry = { type: "agent", value: "team-lead" }
 
@@ -4562,14 +4585,6 @@ export default function PrototypePage() {
         {/* Center: team feed + attention bar + composer */}
         {(!showTopTabs || mainTab === "chat") && (
           <main className="flex-1 min-w-0 flex flex-col min-h-0">
-            {pinnedItem && (
-              <PinnedItemCard
-                item={pinnedItem.item}
-                feedIndex={pinnedItem.feedIndex}
-                onResolvePermission={handleResolvePermission}
-                onResolvePlan={handleResolvePlan}
-              />
-            )}
             <TeamFeed
               feedItems={feedItems}
               agentFilter={effectiveAgentFilter}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -455,7 +455,7 @@ function AssistantMessage({
         />
       </div>
       {content.length > 0 && (
-        <div className="absolute top-0 right-0 opacity-0 group-hover/msg:opacity-100 transition-opacity">
+        <div className="absolute top-0 -left-6 opacity-0 group-hover/msg:opacity-100 transition-opacity">
           <CopyButton text={content} />
         </div>
       )}
@@ -2027,23 +2027,6 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
         )}
       </div>
 
-      {/* Mini composer — message this specific agent */}
-      <div className="px-3 py-2 border-t border-border-subtle">
-        <div className="flex items-center gap-2 rounded-lg border border-border-default bg-surface-sunken/40 px-2.5 py-1.5">
-          <span className="text-[10px] text-accent font-mono shrink-0">@{agent.name}</span>
-          <input
-            type="text"
-            placeholder="Message this agent..."
-            className="flex-1 bg-transparent border-none outline-none text-xs text-default placeholder:text-muted/40 min-w-0"
-          />
-          <button
-            type="button"
-            className="flex items-center justify-center h-5 w-5 rounded-full bg-surface text-muted"
-          >
-            <ArrowUp className="h-3 w-3" strokeWidth={2.5} />
-          </button>
-        </div>
-      </div>
     </div>
   )
 }

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -33,6 +33,8 @@ import {
   Filter,
   Tag,
   Shield,
+  FileText,
+  ChevronDown,
 } from "lucide-react"
 import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -388,7 +390,7 @@ type TeamFeedItem =
   | { type: "status"; agent: string; from: string; to: string }
   | { type: "error"; agent: string; text: string }
   | { type: "question"; agent: string; question: string; options: string[] }
-  | { type: "plan"; agent: string; title: string; steps: { text: string; status: "done" | "current" | "pending" }[]; planStatus: "pending" | "approved" | "rejected" }
+  | { type: "plan"; agent: string; title: string; context: string; steps: { text: string; description?: string; files?: string[]; status: "done" | "current" | "pending" }[]; files: string[]; planStatus: "pending" | "approved" | "rejected" }
   | { type: "permission"; agent: string; command: string; risk?: string; permStatus: "pending" | "allowed" | "denied" }
   | { type: "multi-question"; agent: string; questions: { text: string; options: string[] }[] }
 
@@ -411,13 +413,15 @@ const TEAM_FEED: TeamFeedItem[] = [
     type: "plan",
     agent: "backend",
     title: "Fix JWT validation and add clock skew tolerance",
+    context: "The JWT validation middleware rejects tokens within 5s of expiry due to Date.now() returning milliseconds while the JWT exp claim uses seconds. Adding clock skew tolerance prevents intermittent 401s during server clock drift.",
     steps: [
-      { text: "Read auth.ts and identify expiry comparison bug", status: "done" },
-      { text: "Convert Date.now() to seconds in validateToken()", status: "done" },
-      { text: "Add 30-second clock skew tolerance", status: "current" },
-      { text: "Add structured error logging for validation failures", status: "pending" },
-      { text: "Run lint and existing tests", status: "pending" },
+      { text: "Identify expiry comparison bug", description: "Read auth.ts, trace the validateToken() path to find the ms vs seconds mismatch", files: ["backend/middleware/auth.ts"], status: "done" },
+      { text: "Convert Date.now() to seconds", description: "Replace Date.now() with Math.floor(Date.now() / 1000) in the expiry check", files: ["backend/middleware/auth.ts"], status: "done" },
+      { text: "Add 30s clock skew tolerance", description: "Pass clockTolerance: 30 to jsonwebtoken.verify() options", files: ["backend/middleware/auth.ts", "backend/config/auth.ts"], status: "current" },
+      { text: "Add structured error logging", description: "Log validation failures with token claims, expected vs actual timestamps", files: ["backend/middleware/auth.ts"], status: "pending" },
+      { text: "Run lint and existing tests", files: ["backend/tests/auth.test.ts"], status: "pending" },
     ],
+    files: ["backend/middleware/auth.ts", "backend/config/auth.ts", "backend/tests/auth.test.ts"],
     planStatus: "approved",
   },
 
@@ -517,11 +521,13 @@ const TEAM_FEED: TeamFeedItem[] = [
     type: "plan",
     agent: "devops",
     title: "Deploy auth fix to staging",
+    context: "The auth hotfix needs to reach staging for QA verification before the production rollout window. Build a fresh image from the fix branch, run integration tests against the staging database, then swap traffic with zero downtime.",
     steps: [
-      { text: "Build Docker image with auth changes", status: "done" as const },
-      { text: "Run integration tests in staging env", status: "current" as const },
-      { text: "Swap traffic to new deployment", status: "pending" as const },
+      { text: "Build Docker image with auth changes", description: "docker build from fix/jwt-validation branch, tag as staging-candidate", files: ["backend/Dockerfile", "docker-compose.staging.yml"], status: "done" as const },
+      { text: "Run integration tests in staging env", description: "Execute full auth test suite against staging DB with new image", files: ["tests/integration/auth.test.ts", "tests/integration/refresh.test.ts"], status: "current" as const },
+      { text: "Swap traffic to new deployment", description: "Blue-green deploy — route staging traffic to new containers, drain old ones", files: ["infra/staging/deploy.yaml", "infra/staging/routes.yaml"], status: "pending" as const },
     ],
+    files: ["backend/Dockerfile", "docker-compose.staging.yml", "tests/integration/auth.test.ts", "tests/integration/refresh.test.ts", "infra/staging/deploy.yaml", "infra/staging/routes.yaml"],
     planStatus: "pending" as const,
   },
 
@@ -1110,15 +1116,20 @@ function QuestionCard({
 function PlanCard({
   agent,
   title,
+  context,
   steps,
+  files,
   planStatus: initialStatus,
 }: {
   agent: string
   title: string
-  steps: { text: string; status: "done" | "current" | "pending" }[]
+  context: string
+  steps: { text: string; description?: string; files?: string[]; status: "done" | "current" | "pending" }[]
+  files: string[]
   planStatus: "pending" | "approved" | "rejected"
 }) {
   const [status, setStatus] = useState(initialStatus)
+  const [expanded, setExpanded] = useState(true)
 
   if (status === "approved") {
     return (
@@ -1142,39 +1153,122 @@ function PlanCard({
     )
   }
 
+  const doneCount = steps.filter(s => s.status === "done").length
+  const totalCount = steps.length
+
   return (
     <div className="flex gap-2 min-w-0">
       <ChatAvatar name={agent} />
       <div className="min-w-0 flex-1">
         <div className="text-[11px] text-warning font-mono mb-0.5">{agent} · Proposing a plan</div>
-        <div className="rounded-lg border border-warning/20 bg-surface-raised/60 p-3 max-w-lg">
-          <p className="text-sm font-medium text-default mb-2">{title}</p>
-          <div className="space-y-1.5 mb-3">
-            {steps.map((step, i) => (
-              <div key={i} className="flex items-start gap-2">
-                {step.status === "done" ? (
-                  <Check className="h-3.5 w-3.5 text-success shrink-0 mt-0.5" strokeWidth={2.5} />
-                ) : step.status === "current" ? (
-                  <span className="h-3.5 w-3.5 flex items-center justify-center shrink-0 mt-0.5">
-                    <span className="h-2 w-2 rounded-full bg-warning animate-breathe" />
-                  </span>
-                ) : (
-                  <span className="h-3.5 w-3.5 rounded-full border border-border-default shrink-0 mt-0.5" />
-                )}
-                <span
-                  className={cn(
-                    "text-xs leading-tight",
-                    step.status === "done" && "text-muted line-through",
-                    step.status === "current" && "text-default font-medium",
-                    step.status === "pending" && "text-muted",
-                  )}
-                >
-                  {step.text}
-                </span>
+        <div className="rounded-lg border border-warning/20 bg-surface-raised/60 max-w-xl overflow-hidden">
+          {/* Header — title + summary + expand toggle */}
+          <div className="px-3.5 pt-3 pb-2">
+            <button
+              type="button"
+              onClick={() => setExpanded(e => !e)}
+              className="flex items-start gap-2 w-full text-left group"
+            >
+              <ChevronDown className={cn(
+                "h-3.5 w-3.5 text-muted shrink-0 mt-0.5 transition-transform",
+                !expanded && "-rotate-90",
+              )} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[13px] font-medium text-default leading-snug">{title}</p>
+                <p className="text-[11px] text-muted mt-1 leading-relaxed">{context}</p>
               </div>
-            ))}
+            </button>
+            {/* Progress bar */}
+            <div className="flex items-center gap-2 mt-2.5 ml-5.5">
+              <div className="flex-1 h-1 rounded-full bg-surface-sunken overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-success/60 transition-all"
+                  style={{ width: `${(doneCount / totalCount) * 100}%` }}
+                />
+              </div>
+              <span className="text-[10px] font-mono text-muted shrink-0">{doneCount}/{totalCount}</span>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
+
+          {/* Expanded content — steps + files */}
+          {expanded && (
+            <>
+              {/* Steps */}
+              <div className="border-t border-border-subtle/50 px-3.5 py-2.5">
+                <div className="space-y-0.5">
+                  {steps.map((step, i) => (
+                    <div key={i} className="group/step">
+                      <div className="flex items-start gap-2.5 py-1">
+                        {/* Step number + status */}
+                        <span className={cn(
+                          "w-5 h-5 rounded-md flex items-center justify-center shrink-0 text-[10px] font-mono font-medium",
+                          step.status === "done" && "bg-success/15 text-success",
+                          step.status === "current" && "bg-warning/15 text-warning",
+                          step.status === "pending" && "bg-surface-sunken text-muted",
+                        )}>
+                          {step.status === "done" ? (
+                            <Check className="h-3 w-3" strokeWidth={2.5} />
+                          ) : (
+                            i + 1
+                          )}
+                        </span>
+                        {/* Step text + description */}
+                        <div className="min-w-0 flex-1">
+                          <span className={cn(
+                            "text-xs leading-snug block",
+                            step.status === "done" && "text-muted",
+                            step.status === "current" && "text-default font-medium",
+                            step.status === "pending" && "text-secondary",
+                          )}>
+                            {step.text}
+                          </span>
+                          {step.description && (
+                            <span className="text-[10px] text-muted/70 leading-relaxed block mt-0.5">
+                              {step.description}
+                            </span>
+                          )}
+                          {step.files && step.files.length > 0 && (
+                            <div className="flex flex-wrap gap-1 mt-1">
+                              {step.files.map(f => (
+                                <span key={f} className="inline-flex items-center gap-0.5 text-[9px] font-mono text-muted/60 bg-surface-sunken/60 rounded px-1.5 py-0.5">
+                                  <FileText className="h-2.5 w-2.5" />
+                                  {f.split("/").pop()}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                      {/* Connector line between steps */}
+                      {i < steps.length - 1 && (
+                        <div className="ml-2.5 w-px h-1 bg-border-subtle/40" />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Files affected */}
+              {files.length > 0 && (
+                <div className="border-t border-border-subtle/50 px-3.5 py-2">
+                  <div className="flex items-center gap-1.5 mb-1.5">
+                    <FileText className="h-3 w-3 text-muted/60" />
+                    <span className="text-[10px] font-mono text-muted/60 uppercase tracking-wider">Files affected</span>
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {files.map(f => (
+                      <span key={f} className="text-[10px] font-mono text-secondary/80 bg-surface-sunken/40 rounded px-1.5 py-0.5">
+                        {f}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Actions */}
+          <div className="border-t border-border-subtle/50 px-3.5 py-2.5 flex items-center gap-2">
             <button
               type="button"
               onClick={() => setStatus("approved")}
@@ -2633,6 +2727,135 @@ function ComposerBar({
 /*  PINNED ITEM CARD — shows pending plan/permission at feed top       */
 /* ================================================================== */
 
+type PlanFeedItem = Extract<TeamFeedItem, { type: "plan" }>
+
+function PinnedPlanContent({
+  item,
+  feedIndex,
+  onResolvePlan,
+}: {
+  item: PlanFeedItem
+  feedIndex: number
+  onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
+}) {
+  const doneCount = item.steps.filter(s => s.status === "done").length
+  const totalCount = item.steps.length
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="px-3.5 pt-3 pb-2">
+        <div className="text-[11px] text-warning font-mono mb-1.5">{item.agent} · Proposing a plan</div>
+        <p className="text-[13px] font-medium text-default leading-snug">{item.title}</p>
+        <p className="text-[11px] text-muted mt-1 leading-relaxed">{item.context}</p>
+        {/* Progress bar */}
+        <div className="flex items-center gap-2 mt-2.5">
+          <div className="flex-1 h-1 rounded-full bg-surface-sunken overflow-hidden">
+            <div
+              className="h-full rounded-full bg-success/60 transition-all"
+              style={{ width: `${(doneCount / totalCount) * 100}%` }}
+            />
+          </div>
+          <span className="text-[10px] font-mono text-muted shrink-0">{doneCount}/{totalCount}</span>
+        </div>
+      </div>
+
+      {/* Steps */}
+      <div className="border-t border-border-subtle/50 px-3.5 py-2.5">
+        <div className="space-y-0.5">
+          {item.steps.map((step, i) => (
+            <div key={i}>
+              <div className="flex items-start gap-2.5 py-1">
+                <span className={cn(
+                  "w-5 h-5 rounded-md flex items-center justify-center shrink-0 text-[10px] font-mono font-medium",
+                  step.status === "done" && "bg-success/15 text-success",
+                  step.status === "current" && "bg-warning/15 text-warning",
+                  step.status === "pending" && "bg-surface-sunken text-muted",
+                )}>
+                  {step.status === "done" ? (
+                    <Check className="h-3 w-3" strokeWidth={2.5} />
+                  ) : (
+                    i + 1
+                  )}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span className={cn(
+                    "text-xs leading-snug block",
+                    step.status === "done" && "text-muted",
+                    step.status === "current" && "text-default font-medium",
+                    step.status === "pending" && "text-secondary",
+                  )}>
+                    {step.text}
+                  </span>
+                  {step.description && (
+                    <span className="text-[10px] text-muted/70 leading-relaxed block mt-0.5">
+                      {step.description}
+                    </span>
+                  )}
+                  {step.files && step.files.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {step.files.map(f => (
+                        <span key={f} className="inline-flex items-center gap-0.5 text-[9px] font-mono text-muted/60 bg-surface-sunken/60 rounded px-1.5 py-0.5">
+                          <FileText className="h-2.5 w-2.5" />
+                          {f.split("/").pop()}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+              {i < item.steps.length - 1 && (
+                <div className="ml-2.5 w-px h-1 bg-border-subtle/40" />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Files affected */}
+      {item.files.length > 0 && (
+        <div className="border-t border-border-subtle/50 px-3.5 py-2">
+          <div className="flex items-center gap-1.5 mb-1.5">
+            <FileText className="h-3 w-3 text-muted/60" />
+            <span className="text-[10px] font-mono text-muted/60 uppercase tracking-wider">Files affected</span>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {item.files.map(f => (
+              <span key={f} className="text-[10px] font-mono text-secondary/80 bg-surface-sunken/40 rounded px-1.5 py-0.5">
+                {f}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="border-t border-border-subtle/50 px-3.5 py-2.5 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onResolvePlan(feedIndex, "approved")}
+          className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={() => onResolvePlan(feedIndex, "rejected")}
+          className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  )
+}
+
 function PinnedItemCard({
   item,
   feedIndex,
@@ -2646,57 +2869,9 @@ function PinnedItemCard({
 }) {
   return (
     <div className="px-6 pt-3 pb-1 max-w-3xl mx-auto w-full shrink-0">
-      <div className="rounded-lg border border-warning/25 bg-warning-subtle/5 p-3 border-t-2 border-t-warning/40">
+      <div className="rounded-lg border border-warning/25 bg-warning-subtle/5 border-t-2 border-t-warning/40 overflow-hidden">
         {item.type === "plan" ? (
-          <div className="space-y-2">
-            <div className="text-[11px] text-warning font-mono">{item.agent} · Proposing a plan</div>
-            <p className="text-sm font-medium text-default">{item.title}</p>
-            <div className="space-y-1.5">
-              {item.steps.map((step, i) => (
-                <div key={i} className="flex items-start gap-2">
-                  {step.status === "done" ? (
-                    <Check className="h-3.5 w-3.5 text-success shrink-0 mt-0.5" strokeWidth={2.5} />
-                  ) : step.status === "current" ? (
-                    <span className="h-3.5 w-3.5 flex items-center justify-center shrink-0 mt-0.5">
-                      <span className="h-2 w-2 rounded-full bg-warning animate-breathe" />
-                    </span>
-                  ) : (
-                    <span className="h-3.5 w-3.5 rounded-full border border-border-default shrink-0 mt-0.5" />
-                  )}
-                  <span className={cn(
-                    "text-xs leading-tight",
-                    step.status === "done" && "text-muted line-through",
-                    step.status === "current" && "text-default font-medium",
-                    step.status === "pending" && "text-muted",
-                  )}>
-                    {step.text}
-                  </span>
-                </div>
-              ))}
-            </div>
-            <div className="flex items-center gap-2 pt-1">
-              <button
-                type="button"
-                onClick={() => onResolvePlan(feedIndex, "approved")}
-                className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
-              >
-                Approve
-              </button>
-              <button
-                type="button"
-                className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
-              >
-                Edit
-              </button>
-              <button
-                type="button"
-                onClick={() => onResolvePlan(feedIndex, "rejected")}
-                className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
-              >
-                Reject
-              </button>
-            </div>
-          </div>
+          <PinnedPlanContent item={item} feedIndex={feedIndex} onResolvePlan={onResolvePlan} />
         ) : (
           <div className="space-y-2">
             <div className="text-[11px] text-info font-mono">
@@ -2957,7 +3132,7 @@ function TeamFeed({
             case "question":
               return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
             case "plan":
-              return <PlanCard key={i} agent={item.agent} title={item.title} steps={item.steps} planStatus={item.planStatus} />
+              return <PlanCard key={i} agent={item.agent} title={item.title} context={item.context} steps={item.steps} files={item.files} planStatus={item.planStatus} />
             case "permission":
               return <PermissionCard key={i} agent={item.agent} command={item.command} risk={item.risk} permStatus={item.permStatus} />
             case "multi-question":
@@ -4279,54 +4454,44 @@ function ResizeHandle({
   onReset?: () => void
   side?: "left" | "right"
 }) {
-  const dragging = useRef(false)
   const lastX = useRef(0)
+  const [active, setActive] = useState(false)
 
-  const onPointerDown = useCallback(
-    (e: React.PointerEvent) => {
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
       e.preventDefault()
-      dragging.current = true
       lastX.current = e.clientX
-      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
-    },
-    [],
-  )
-
-  const onPointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!dragging.current) return
-      const delta = e.clientX - lastX.current
-      lastX.current = e.clientX
-      // For left-edge handle: dragging left = positive resize (panel grows)
-      onResize(side === "left" ? -delta : delta)
+      setActive(true)
+      document.documentElement.classList.add("dragging-resize")
+      const move = (ev: MouseEvent) => {
+        const delta = ev.clientX - lastX.current
+        lastX.current = ev.clientX
+        onResize(side === "left" ? -delta : delta)
+      }
+      const up = () => {
+        setActive(false)
+        document.documentElement.classList.remove("dragging-resize")
+        document.removeEventListener("mousemove", move)
+        document.removeEventListener("mouseup", up)
+      }
+      document.addEventListener("mousemove", move)
+      document.addEventListener("mouseup", up)
     },
     [onResize, side],
   )
 
-  const onPointerUp = useCallback(() => {
-    dragging.current = false
-  }, [])
-
-  const onPointerCancel = useCallback(() => {
-    dragging.current = false
-  }, [])
-
   return (
     <div
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={onPointerCancel}
+      onMouseDown={onMouseDown}
       onDoubleClick={onReset}
       className={cn(
-        "absolute top-0 bottom-0 w-3 z-(--z-dropdown) cursor-col-resize group/resize",
+        "absolute top-0 bottom-0 w-3 z-(--z-dropdown) hover:cursor-col-resize",
         side === "left" ? "-left-1.5" : "-right-1.5",
       )}
     >
-      {/* Full-height border highlight on hover/drag */}
       <div className={cn(
         "absolute inset-y-0 w-0.5 transition-colors",
-        "bg-transparent group-hover/resize:bg-accent/50 group-active/resize:bg-accent",
+        active ? "bg-accent/50" : "bg-transparent",
         side === "left" ? "left-1.5" : "right-1.5",
       )} />
     </div>
@@ -4476,22 +4641,38 @@ export default function PrototypePage() {
   const showTopTabs = bp === "mobile"
   const showLeftPanel = bp !== "mobile"
 
-  // Left panel width: custom if user has resized, else breakpoint default
-  const defaultLeftWidth = bp === "S" ? 340 : bp === "M" ? 340 : 480
+  // Left panel width: scale with screen, collapse threshold = 25% of viewport
+  const screenWidth = typeof window !== "undefined" ? window.innerWidth : 1920
+  const collapseThreshold = Math.round(screenWidth * 0.2)
+  const minPanelWidth = collapseThreshold + 20
+  const defaultLeftWidth = bp === "S" ? Math.max(minPanelWidth, 320) : bp === "M" ? Math.max(minPanelWidth, 340) : 480
   const effectiveLeftWidth = leftPanelWidth ?? defaultLeftWidth
 
   const handleLeftPanelResize = useCallback((delta: number) => {
     setLeftPanelWidth((prev) => {
       const current = prev ?? defaultLeftWidth
       const next = current + delta
-      // Snap to collapsed if dragged below threshold
-      if (next < 360) {
+      if (next < collapseThreshold) {
         setAgentPanelOpen(false)
-        return null // reset to default for when they re-expand
+        return null
       }
-      return Math.max(360, Math.min(720, next))
+      return Math.max(minPanelWidth, Math.min(720, next))
     })
-  }, [defaultLeftWidth])
+  }, [defaultLeftWidth, collapseThreshold, minPanelWidth])
+
+  // When re-expanding, set width above collapse threshold to prevent insta-collapse
+  const handleTogglePanelOpen = useCallback(() => {
+    setAgentPanelOpen(prev => {
+      if (!prev) {
+        // expanding — ensure width is safely above collapse threshold
+        setLeftPanelWidth(cur => {
+          const w = cur ?? defaultLeftWidth
+          return Math.max(w, collapseThreshold + 40)
+        })
+      }
+      return !prev
+    })
+  }, [defaultLeftWidth, collapseThreshold])
 
   // Top tabs (small screens)
   const topTabs = [
@@ -4501,7 +4682,7 @@ export default function PrototypePage() {
   ]
 
   return (
-    <div className="h-screen flex bg-surface overflow-hidden">
+    <div className="h-screen flex bg-surface overflow-hidden cursor-default">
       <h1 className="sr-only">Agentobox Dashboard</h1>
 
       {/* Secrets modal */}
@@ -4520,7 +4701,7 @@ export default function PrototypePage() {
           onToggleExpandAll={handleToggleExpandAll}
           onOpenSecrets={() => setSecretsOpen(true)}
           isOpen={agentPanelOpen}
-          onToggleOpen={() => setAgentPanelOpen((p) => !p)}
+          onToggleOpen={handleTogglePanelOpen}
           width={effectiveLeftWidth}
           onResize={handleLeftPanelResize}
           onResetWidth={() => setLeftPanelWidth(null)}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -27,6 +27,10 @@ import {
   Settings,
   Monitor,
   List,
+  BookOpen,
+  Search,
+  Filter,
+  Tag,
 } from "lucide-react"
 import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -58,6 +62,7 @@ type FakeAgent = {
   mcpServers: string[]
   runtime: "docker" | "modal"
   workspacePath: string
+  tags: string[]
 }
 
 const AGENTS: FakeAgent[] = [
@@ -78,6 +83,7 @@ const AGENTS: FakeAgent[] = [
     mcpServers: ["computer-use"],
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
+    tags: ["backend", "core"],
   },
   {
     id: "2",
@@ -95,6 +101,7 @@ const AGENTS: FakeAgent[] = [
     mcpServers: ["playwright", "computer-use"],
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
+    tags: ["frontend", "core"],
   },
   {
     id: "3",
@@ -111,6 +118,7 @@ const AGENTS: FakeAgent[] = [
     mcpServers: ["playwright"],
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
+    tags: ["testing", "ci"],
   },
   {
     id: "4",
@@ -126,6 +134,7 @@ const AGENTS: FakeAgent[] = [
     mcpServers: ["computer-use"],
     runtime: "modal",
     workspacePath: "/workspace/agentobox",
+    tags: ["infra", "ci"],
   },
   {
     id: "5",
@@ -142,6 +151,7 @@ const AGENTS: FakeAgent[] = [
     mcpServers: [],
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
+    tags: ["docs"],
   },
   {
     id: "6",
@@ -157,6 +167,7 @@ const AGENTS: FakeAgent[] = [
     mcpServers: [],
     runtime: "modal",
     workspacePath: "/workspace/agentobox",
+    tags: ["infra"],
   },
 ]
 
@@ -173,6 +184,117 @@ const SECRETS: FakeSecret[] = [
   { id: "s3", key: "AWS_ACCESS_KEY_ID", value: "AKIAIOSFODNN7EXAMPLE", addedAgo: "1w ago" },
   { id: "s4", key: "OPENAI_API_KEY", value: "sk-proj-xxxxxxxxxxxxxxxx", addedAgo: "1w ago" },
 ]
+
+/* ================================================================== */
+/*  SKILLS DATA                                                        */
+/* ================================================================== */
+
+type Skill = {
+  id: string
+  name: string
+  description: string
+  content: string
+  assignedTags: string[]
+  steps?: number
+}
+
+const SKILLS: Skill[] = [
+  {
+    id: "sk1",
+    name: "Test Failure Triage",
+    description: "Systematic approach to diagnosing test failures",
+    assignedTags: ["testing", "core"],
+    steps: 5,
+    content: `# Test Failure Triage
+
+1. **Read the error message** — don't skip to the code. The error tells you what failed, the stack trace tells you where.
+2. **Reproduce locally** — run the exact failing test in isolation:
+   \`\`\`bash
+   npm test -- --filter <test-name>
+   \`\`\`
+   - If it passes locally, the issue is environment-specific
+   - If it fails, you have a local repro
+3. **Check recent changes** — \`git log --oneline -10\` in the affected area
+   - Did a dependency change?
+   - Did a related module change its contract?
+4. **Isolate the assertion** — which specific assertion fails?
+   - Expected vs actual values
+   - Is the test wrong or the code wrong?
+5. **Fix and verify** — apply the fix, run the full suite:
+   - Run the specific test
+   - Run the full suite to check for regressions
+   - If flaky, add a note about the flakiness pattern`,
+  },
+  {
+    id: "sk2",
+    name: "Frontend Design Guidelines",
+    description: "Typography, color, and motion standards",
+    assignedTags: ["frontend"],
+    content: `# Frontend Design Guidelines
+
+## Typography
+Use the system font stack. Body text at 14px, labels at 11px, headings at 16-20px. Monospace for code, data, and technical content. Line height: 1.5 for body, 1.2 for headings.
+
+## Color
+Follow the semantic token system. Never use raw hex values — always reference design tokens (\`text-default\`, \`text-muted\`, \`bg-surface\`, etc.). Status colors: success (green), warning (amber), danger (red), info (blue), accent (brand purple).
+
+## Motion
+Transitions at 150ms for micro-interactions (hover, focus), 200ms for reveals (collapsible, dropdown), 300ms for layout shifts (panel resize). Use \`ease-out\` for enters, \`ease-in\` for exits. No animation on reduced-motion preference.
+
+## Spacing
+Use the 4px grid. Common values: 4, 8, 12, 16, 24, 32. Padding inside cards: 12px. Gap between cards: 8px. Section spacing: 16-24px.`,
+  },
+  {
+    id: "sk3",
+    name: "PR Review Checklist",
+    description: "Code review standards for all pull requests",
+    assignedTags: ["core"],
+    steps: 5,
+    content: `# PR Review Checklist
+
+1. **Scope check** — does the PR do one thing? If the title needs "and", it should be two PRs.
+2. **Read the tests first** — tests document intent. If there are no tests, that's the first comment.
+3. **Check the unhappy path** — error handling, edge cases, null/undefined guards at boundaries.
+   > Note: internal code trusts normalized data — only validate at system boundaries.
+4. **Review naming** — do variable/function names describe what they DO, not what they ARE? \`fetchUserProfile\` > \`getData\`.
+5. **Check for regressions** — does this change break existing behavior? Look for:
+   - Changed function signatures
+   - Removed exports
+   - Modified database schemas
+   - Altered API response shapes`,
+  },
+  {
+    id: "sk4",
+    name: "Deploy Verification",
+    description: "Post-deploy health checks and rollback criteria",
+    assignedTags: ["infra", "ci"],
+    steps: 3,
+    content: `# Deploy Verification
+
+1. **Health check** — hit the health endpoint within 30s of deploy:
+   \`\`\`bash
+   curl -s https://api.example.com/health | jq .
+   \`\`\`
+   - If status != "ok" → **rollback immediately**
+   - If latency > 2s → investigate but don't rollback yet
+2. **Smoke test core flows** — run the critical path tests:
+   - Authentication (login, token refresh)
+   - Primary CRUD operations
+   - WebSocket connections (if applicable)
+   - If any fail → **rollback**
+3. **Monitor for 15 minutes** — watch error rates and p99 latency:
+   - Error rate > 1% → **rollback**
+   - p99 latency > 2x baseline → investigate
+   - All clear after 15m → deploy is stable`,
+  },
+]
+
+function getAgentSkills(agent: FakeAgent): Skill[] {
+  return SKILLS.filter(s => s.assignedTags.some(tag => agent.tags.includes(tag)))
+}
+
+/** All unique tags across agents */
+const ALL_TAGS = Array.from(new Set(AGENTS.flatMap(a => a.tags))).sort()
 
 /**
  * FAKE_MARKDOWN — used in right-panel agent detail feed.
@@ -1274,6 +1396,12 @@ function AgentLeftPanel({
   onResize: (delta: number) => void
   onResetWidth: () => void
 }) {
+  const [panelTab, setPanelTab] = useState<"agents" | "skills">("agents")
+  const [searchQuery, setSearchQuery] = useState("")
+  const [tagFilter, setTagFilter] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [showTagDropdown, setShowTagDropdown] = useState(false)
+
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
     for (const a of agents) counts[a.status] = (counts[a.status] ?? 0) + 1
@@ -1281,6 +1409,29 @@ function AgentLeftPanel({
   }, [agents])
 
   const totalCost = useMemo(() => agents.reduce((sum, a) => sum + a.cost, 0), [agents])
+
+  const filteredAgents = useMemo(() => {
+    let result = agents
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(a => a.name.toLowerCase().includes(q))
+    }
+    if (tagFilter) {
+      result = result.filter(a => a.tags.includes(tagFilter))
+    }
+    return result
+  }, [agents, searchQuery, tagFilter])
+
+  const selectable = selectedIds.size > 0
+
+  const handleSelectAgent = useCallback((id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
 
   /* ---- Collapsed state: 48px icon rail ---- */
   if (!isOpen) {
@@ -1392,7 +1543,7 @@ function AgentLeftPanel({
       <div className="h-10 px-3 flex items-center border-b border-border-default shrink-0">
         <button
           type="button"
-          className="inline-flex items-center gap-2 px-1 py-1 -ml-1 rounded-md hover:bg-surface-sunken/40 transition-colors"
+          className="inline-flex items-center gap-2 px-1 py-1 -ml-1 rounded-md hover:bg-surface-sunken/40 transition-colors flex-1 min-w-0"
         >
           <div className="h-6 w-6 rounded-md bg-accent/15 flex items-center justify-center text-[11px] font-bold text-accent shrink-0">
             A
@@ -1400,60 +1551,185 @@ function AgentLeftPanel({
           <span className="text-sm font-medium text-default">agentobox</span>
           <ChevronRight size={12} className="text-muted/40 rotate-90 shrink-0" />
         </button>
-      </div>
-
-      {/* Panel header: title + expand-all + collapse */}
-      <div className="h-8 px-3 flex items-center gap-2 border-b border-border-default shrink-0">
-        <Users className="h-3.5 w-3.5 text-muted" />
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted flex-1">
-          Agents
-        </span>
-        <button
-          type="button"
-          onClick={onToggleExpandAll}
-          className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
-          title="Cycle card states"
-        >
-          {expandedIds.size > 0 ? (
-            <ChevronsDownUp className="h-3.5 w-3.5" />
-          ) : (
-            <ChevronsUpDown className="h-3.5 w-3.5" />
-          )}
-        </button>
         <button
           type="button"
           onClick={onToggleOpen}
-          className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+          className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors shrink-0"
           title="Collapse panel"
         >
           <ChevronLeft className="h-3.5 w-3.5" />
         </button>
       </div>
 
-      {/* Agent cards */}
-      <ScrollArea className="flex-1 overflow-y-auto">
-        <div className="p-3 space-y-2">
-          {agents.map((agent) => (
-            <AgentCardRow
-              key={agent.id}
-              agent={agent}
-              isOpen={expandedIds.has(agent.id)}
-              onToggle={() => onToggleAgent(agent.id)}
-            />
-          ))}
-        </div>
-      </ScrollArea>
-
-      {/* Fleet health horizontal */}
-      <div className="px-3 py-1.5 border-t border-border-subtle flex items-center gap-2">
-        <FleetHealthPills statusCounts={statusCounts} layout="horizontal" />
-        <span className="text-[9px] text-muted/40 font-mono ml-auto">
-          {agents.length} agents
-        </span>
+      {/* Panel tabs: Agents | Skills */}
+      <div className="h-7 px-3 flex items-center gap-1 border-b border-border-default shrink-0">
+        <button
+          type="button"
+          onClick={() => setPanelTab("agents")}
+          className={cn(
+            "inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors",
+            panelTab === "agents"
+              ? "bg-surface-raised text-default"
+              : "text-muted hover:text-secondary hover:bg-surface-raised/30",
+          )}
+        >
+          <Users className="h-3 w-3" />
+          Agents
+        </button>
+        <button
+          type="button"
+          onClick={() => setPanelTab("skills")}
+          className={cn(
+            "inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors",
+            panelTab === "skills"
+              ? "bg-surface-raised text-default"
+              : "text-muted hover:text-secondary hover:bg-surface-raised/30",
+          )}
+        >
+          <BookOpen className="h-3 w-3" />
+          Skills
+        </button>
+        <span className="flex-1" />
+        {panelTab === "agents" && (
+          <button
+            type="button"
+            onClick={onToggleExpandAll}
+            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+            title="Cycle card states"
+          >
+            {expandedIds.size > 0 ? (
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
       </div>
 
+      {/* Tab content */}
+      {panelTab === "agents" ? (
+        <>
+          {/* Agent filter bar */}
+          <div className="px-3 py-2 flex items-center gap-2 border-b border-border-subtle shrink-0">
+            <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded-md border border-border-default bg-surface-sunken/40 px-2 py-1">
+              <Search className="h-3 w-3 text-muted/50 shrink-0" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search agents..."
+                className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
+              />
+            </div>
+            <div className="relative shrink-0">
+              <button
+                type="button"
+                onClick={() => setShowTagDropdown(!showTagDropdown)}
+                className={cn(
+                  "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors",
+                  tagFilter
+                    ? "border-accent/30 bg-accent/10 text-accent"
+                    : "border-border-default text-muted hover:text-secondary hover:bg-surface-raised/40",
+                )}
+              >
+                <Filter className="h-3 w-3" />
+                {tagFilter || "Tags"}
+                <ChevronRight size={10} className="rotate-90 text-muted/40" />
+              </button>
+              {showTagDropdown && (
+                <div className="absolute top-full right-0 mt-1 w-32 rounded-md border border-border-default bg-surface-raised shadow-lg z-(--z-dropdown) overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => { setTagFilter(null); setShowTagDropdown(false) }}
+                    className={cn(
+                      "w-full text-left px-3 py-1.5 text-[11px] transition-colors",
+                      !tagFilter ? "text-accent bg-accent/10" : "text-secondary hover:bg-surface-sunken/40",
+                    )}
+                  >
+                    All tags
+                  </button>
+                  {ALL_TAGS.map(tag => (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => { setTagFilter(tag); setShowTagDropdown(false) }}
+                      className={cn(
+                        "w-full text-left px-3 py-1.5 text-[11px] font-mono transition-colors",
+                        tagFilter === tag ? "text-accent bg-accent/10" : "text-secondary hover:bg-surface-sunken/40",
+                      )}
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Agent cards */}
+          <ScrollArea className="flex-1 overflow-y-auto">
+            <div className="p-3 space-y-2">
+              {filteredAgents.map((agent) => (
+                <AgentCardRow
+                  key={agent.id}
+                  agent={agent}
+                  isOpen={expandedIds.has(agent.id)}
+                  onToggle={() => onToggleAgent(agent.id)}
+                  selectable={selectable}
+                  selected={selectedIds.has(agent.id)}
+                  onSelect={() => handleSelectAgent(agent.id)}
+                />
+              ))}
+              {filteredAgents.length === 0 && (
+                <div className="py-6 text-center">
+                  <Users className="h-5 w-5 text-muted/20 mx-auto mb-1" />
+                  <p className="text-[11px] text-muted/50">No agents match filters</p>
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+
+          {/* Bulk action bar — when agents are selected */}
+          {selectedIds.size > 0 && (
+            <div className="px-3 py-1.5 border-t border-border-subtle bg-surface-sunken/30 flex items-center gap-2 shrink-0">
+              <span className="text-[11px] font-medium text-default shrink-0">
+                {selectedIds.size} selected
+              </span>
+              <select
+                className="bg-surface-sunken/60 border border-border-default rounded-md px-2 py-1 text-[11px] text-secondary outline-none"
+                defaultValue=""
+                onChange={() => {}}
+              >
+                <option value="" disabled>Assign skill...</option>
+                {SKILLS.map(s => (
+                  <option key={s.id} value={s.id}>{s.name}</option>
+                ))}
+              </select>
+              <span className="flex-1" />
+              <button
+                type="button"
+                onClick={() => setSelectedIds(new Set())}
+                className="text-[11px] text-muted hover:text-secondary transition-colors"
+              >
+                Clear
+              </button>
+            </div>
+          )}
+
+          {/* Fleet health horizontal */}
+          <div className="px-3 py-1.5 border-t border-border-subtle flex items-center gap-2 shrink-0">
+            <FleetHealthPills statusCounts={statusCounts} layout="horizontal" />
+            <span className="text-[9px] text-muted/40 font-mono ml-auto">
+              {agents.length} agents
+            </span>
+          </div>
+        </>
+      ) : (
+        <SkillsPanel />
+      )}
+
       {/* Bottom toolbar: secrets + cost + user */}
-      <div className="px-3 py-2 border-t border-border-default flex items-center gap-3">
+      <div className="px-3 py-2 border-t border-border-default flex items-center gap-3 shrink-0">
         <button
           type="button"
           onClick={onOpenSecrets}
@@ -1758,7 +2034,100 @@ function AgentSettingsPanel({ agent }: { agent: FakeAgent }) {
   )
 }
 
-type ViewMode = "terminal" | "feed" | "settings"
+/* ================================================================== */
+/*  AGENT SKILLS VIEW — per-agent skills in card view                  */
+/* ================================================================== */
+
+function AgentSkillsView({ agent }: { agent: FakeAgent }) {
+  const skills = getAgentSkills(agent)
+  const [expandedSkill, setExpandedSkill] = useState<string | null>(null)
+
+  return (
+    <div className="px-3 py-3 space-y-3">
+      {/* Agent tags */}
+      <div>
+        <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1.5">
+          Tags
+        </label>
+        {agent.tags.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {agent.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent/10 border border-accent/20 text-[11px] font-mono text-accent"
+              >
+                <Tag className="h-2.5 w-2.5" />
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="text-[11px] text-muted/50 font-mono">no tags</span>
+        )}
+      </div>
+
+      {/* Inherited skills */}
+      <div>
+        <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1.5">
+          Inherited Skills
+        </label>
+        {skills.length === 0 ? (
+          <div className="py-4 text-center rounded-md border border-border-subtle bg-surface-sunken/20">
+            <BookOpen className="h-5 w-5 text-muted/20 mx-auto mb-1" />
+            <p className="text-[11px] text-muted/50">No skills assigned via tags</p>
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            {skills.map((skill) => {
+              const isExpanded = expandedSkill === skill.id
+              const sourceTag = skill.assignedTags.find(t => agent.tags.includes(t))
+              return (
+                <div key={skill.id} className="rounded-md border border-border-subtle overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedSkill(isExpanded ? null : skill.id)}
+                    className="w-full text-left px-2.5 py-2 flex items-center gap-2 hover:bg-surface-sunken/30 transition-colors"
+                  >
+                    <ChevronRight
+                      size={12}
+                      className={cn(
+                        "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+                        isExpanded && "rotate-90",
+                      )}
+                    />
+                    <span className="text-xs font-medium text-default flex-1 min-w-0 truncate">
+                      {skill.name}
+                    </span>
+                    {sourceTag && (
+                      <span className="text-[9px] font-mono text-muted/60 shrink-0">
+                        via {sourceTag}
+                      </span>
+                    )}
+                    {skill.steps && (
+                      <span className="text-[9px] font-mono text-info/60 shrink-0">
+                        {skill.steps} steps
+                      </span>
+                    )}
+                  </button>
+                  <Collapsible open={isExpanded}>
+                    <div className="px-2.5 pb-2.5 border-t border-border-subtle">
+                      <MarkdownRenderer
+                        content={skill.content}
+                        className="text-xs text-secondary"
+                      />
+                    </div>
+                  </Collapsible>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+type ViewMode = "terminal" | "feed" | "settings" | "skills"
 
 /**
  * Agent card — two states:
@@ -1773,10 +2142,16 @@ function AgentCardRow({
   agent,
   isOpen,
   onToggle,
+  selectable = false,
+  selected = false,
+  onSelect,
 }: {
   agent: FakeAgent
   isOpen: boolean
   onToggle: () => void
+  selectable?: boolean
+  selected?: boolean
+  onSelect?: () => void
 }) {
   const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
   const isRunning = agent.status === "running"
@@ -1787,6 +2162,7 @@ function AgentCardRow({
   const VIEW_MODES: { id: ViewMode; icon: typeof Monitor; label: string }[] = [
     { id: "terminal", icon: Monitor, label: "Screen" },
     { id: "feed", icon: List, label: "Feed" },
+    { id: "skills", icon: BookOpen, label: "Skills" },
     { id: "settings", icon: Settings, label: "Settings" },
   ]
 
@@ -1806,10 +2182,32 @@ function AgentCardRow({
       {/* Header row — always visible, click to toggle */}
       <button
         type="button"
-        onClick={onToggle}
+        onClick={(e) => {
+          if (e.shiftKey && onSelect) {
+            onSelect()
+            return
+          }
+          if (selectable && onSelect) {
+            onSelect()
+          } else {
+            onToggle()
+          }
+        }}
         className="w-full text-left px-2.5 py-2"
       >
         <div className="flex items-center gap-2 min-w-0">
+          {selectable && (
+            <div
+              className={cn(
+                "h-3.5 w-3.5 rounded border flex items-center justify-center shrink-0",
+                selected
+                  ? "bg-accent/20 border-accent/50"
+                  : "border-border-default",
+              )}
+            >
+              {selected && <Check className="h-2.5 w-2.5 text-accent" strokeWidth={3} />}
+            </div>
+          )}
           <AgentAvatar name={agent.name} size="sm" stopped={isStopped} />
           <span
             className={cn(
@@ -1819,6 +2217,19 @@ function AgentCardRow({
           >
             {agent.name}
           </span>
+          {/* Tag pills — max 2 + overflow */}
+          {agent.tags.length > 0 && (
+            <span className="inline-flex items-center gap-1 shrink-0">
+              {agent.tags.slice(0, 2).map((tag) => (
+                <span key={tag} className="px-1.5 py-px rounded text-[9px] font-mono text-muted bg-surface-sunken/60 border border-border-subtle">
+                  {tag}
+                </span>
+              ))}
+              {agent.tags.length > 2 && (
+                <span className="text-[9px] text-muted/40 font-mono">+{agent.tags.length - 2}</span>
+              )}
+            </span>
+          )}
           <span
             className={cn(
               "h-1.5 w-1.5 rounded-full shrink-0",
@@ -1858,6 +2269,7 @@ function AgentCardRow({
         <div className="px-3 pb-2">
           {viewMode === "terminal" && <VncThumbnail agent={agent} />}
           {viewMode === "feed" && <AgentDetailFeed agent={agent} />}
+          {viewMode === "skills" && <AgentSkillsView agent={agent} />}
           {viewMode === "settings" && <AgentSettingsPanel agent={agent} />}
         </div>
 
@@ -1928,16 +2340,7 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
 
   return (
     <div className="border-t border-border-subtle flex flex-col">
-      {/* Mini-feed header */}
-      <div className="px-3 py-1.5 flex items-center gap-2 bg-surface-sunken/30">
-        <MessageSquare className="h-3 w-3 text-muted/60" />
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted/60">
-          Detail Feed
-        </span>
-        <span className="text-[9px] text-muted/40 font-mono">
-          source: content blocks
-        </span>
-      </div>
+
 
       {/* Historical content only — scrollable mini-feed */}
       <div className="flex-1 min-h-0 max-h-[320px] overflow-y-auto px-3 py-2 space-y-2">
@@ -2027,6 +2430,156 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
         )}
       </div>
 
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  SKILLS PANEL — skills tab content in left panel                    */
+/* ================================================================== */
+
+function SkillsPanel() {
+  const [search, setSearch] = useState("")
+  const [expandedSkill, setExpandedSkill] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [newContent, setNewContent] = useState("")
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return SKILLS
+    const q = search.toLowerCase()
+    return SKILLS.filter(s =>
+      s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
+    )
+  }, [search])
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Search + create */}
+      <div className="px-3 py-2 flex items-center gap-2 border-b border-border-subtle shrink-0">
+        <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded-md border border-border-default bg-surface-sunken/40 px-2 py-1">
+          <Search className="h-3 w-3 text-muted/50 shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search skills..."
+            className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowCreate(!showCreate)}
+          className={cn(
+            "inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors shrink-0",
+            showCreate
+              ? "bg-accent/15 text-accent"
+              : "text-muted hover:text-secondary hover:bg-surface-raised/50",
+          )}
+        >
+          <Plus className="h-3 w-3" />
+          Create
+        </button>
+      </div>
+
+      {/* Create form */}
+      <Collapsible open={showCreate}>
+        <div className="px-3 py-2 border-b border-border-subtle space-y-2 bg-surface-sunken/20">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Skill name..."
+            className="w-full bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs text-default placeholder:text-muted/40 outline-none focus:border-accent/50 transition-colors"
+          />
+          <textarea
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="Markdown content..."
+            rows={4}
+            className="w-full bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs font-mono text-default placeholder:text-muted/40 outline-none focus:border-accent/50 transition-colors resize-none"
+          />
+          <div className="flex justify-end">
+            <button
+              type="button"
+              disabled={!newName.trim()}
+              className={cn(
+                "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                newName.trim()
+                  ? "bg-accent text-on-emphasis hover:bg-accent-hover"
+                  : "bg-surface-sunken text-muted cursor-not-allowed",
+              )}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </Collapsible>
+
+      {/* Skills list */}
+      <ScrollArea className="flex-1 overflow-y-auto">
+        <div className="p-3 space-y-1.5">
+          {filtered.length === 0 ? (
+            <div className="py-8 text-center">
+              <BookOpen className="h-6 w-6 text-muted/20 mx-auto mb-1.5" />
+              <p className="text-[11px] text-muted/50">No skills found</p>
+            </div>
+          ) : (
+            filtered.map((skill) => {
+              const isExpanded = expandedSkill === skill.id
+              return (
+                <div key={skill.id} className="rounded-lg border border-border-subtle overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedSkill(isExpanded ? null : skill.id)}
+                    className="w-full text-left px-2.5 py-2 hover:bg-surface-raised/30 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <ChevronRight
+                        size={12}
+                        className={cn(
+                          "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+                          isExpanded && "rotate-90",
+                        )}
+                      />
+                      <span className="text-xs font-medium text-default flex-1 min-w-0 truncate">
+                        {skill.name}
+                      </span>
+                      {skill.steps ? (
+                        <span className="text-[9px] font-mono text-info/60 shrink-0">
+                          {skill.steps} steps
+                        </span>
+                      ) : (
+                        <span className="text-[9px] font-mono text-muted/40 shrink-0">
+                          skill
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-1 ml-5">
+                      {skill.assignedTags.map((tag) => (
+                        <span key={tag} className="px-1.5 py-px rounded text-[9px] font-mono text-accent/70 bg-accent/8 border border-accent/15">
+                          {tag}
+                        </span>
+                      ))}
+                      <span className="text-[9px] text-muted/40 font-mono">
+                        {skill.description.length > 40 ? skill.description.slice(0, 40) + "..." : skill.description}
+                      </span>
+                    </div>
+                  </button>
+                  <Collapsible open={isExpanded}>
+                    <div className="px-3 pb-3 border-t border-border-subtle bg-surface-sunken/10">
+                      <MarkdownRenderer
+                        content={skill.content}
+                        className="text-xs text-secondary"
+                      />
+                    </div>
+                  </Collapsible>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -10,6 +10,7 @@ import {
   Check,
   X,
   AlertCircle,
+  Paperclip,
   Plus,
 
   Clock,
@@ -71,7 +72,33 @@ type FakeAgent = {
   mode: "auto" | "plan" | "supervised"
 }
 
+type RecipientEntry =
+  | { type: "agent"; value: string }
+  | { type: "tag"; value: string }
+  | { type: "all" }
+
 const INITIAL_AGENTS: FakeAgent[] = [
+  {
+    id: "0",
+    name: "team-lead",
+    lifecycleStatus: "running",
+    attentionLevel: "none",
+    task: "Coordinating sprint tasks",
+    cost: 0.18,
+    duration: "12m 05s",
+    model: "Opus 4.6",
+    turns: 14,
+    lastOutput: "Delegated auth fix to backend, waiting on QA...",
+    phase: "Planning",
+    liveAction: "Reviewing agent progress",
+    todoProgress: { done: 3, total: 5 },
+    instructions: "Orchestrate the team. Break down tasks, delegate to specialists, track progress, resolve blockers. You are the single point of contact for the human.",
+    mcpServers: [],
+    runtime: "docker",
+    workspacePath: "/workspace/agentobox",
+    tags: ["core"],
+    mode: "plan",
+  },
   {
     id: "1",
     name: "backend",
@@ -1504,6 +1531,7 @@ function AgentSummaryCard({
   turns,
   duration,
   isError = false,
+  onClickAgent,
 }: {
   agent: string
   summary: string
@@ -1511,10 +1539,13 @@ function AgentSummaryCard({
   turns: number
   duration: string
   isError?: boolean
+  onClickAgent?: (name: string) => void
 }) {
   return (
     <div className="flex gap-2.5 min-w-0">
-      <ChatAvatar name={agent} />
+      <button type="button" onClick={() => onClickAgent?.(agent)} className="shrink-0 cursor-pointer">
+        <ChatAvatar name={agent} />
+      </button>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 mb-0.5">
           <span className="text-[11px] text-muted font-mono">{agent}</span>
@@ -1547,12 +1578,14 @@ function AgentSummaryCard({
  * Status transition line — inline status change notification.
  * SOURCE: StreamEvent status change (agent.status field transitions)
  */
-function AgentStatusLine({ agent, from, to }: { agent: string; from: string; to: string }) {
+function AgentStatusLine({ agent, from, to, onClickAgent }: { agent: string; from: string; to: string; onClickAgent?: (name: string) => void }) {
   const toConfig = LIFECYCLE_CONFIG[to as LifecycleStatus] ?? LIFECYCLE_CONFIG.stopped
 
   return (
     <div className="flex items-center justify-center gap-2 py-0.5">
-      <AgentAvatar name={agent} size="sm" />
+      <button type="button" onClick={() => onClickAgent?.(agent)} className="shrink-0 cursor-pointer">
+        <AgentAvatar name={agent} size="sm" />
+      </button>
       <span className="text-[10px] text-muted font-mono">
         {agent}
       </span>
@@ -1592,12 +1625,14 @@ function TeamUserMessage({ text, target }: { text: string; target?: string }) {
  * Team error alert — prominent error from an agent.
  * SOURCE: StreamEvent with isError flag, or TimelineEntry.summary with error content
  */
-function TeamErrorAlert({ agent, text }: { agent: string; text: string }) {
+function TeamErrorAlert({ agent, text, onClickAgent }: { agent: string; text: string; onClickAgent?: (name: string) => void }) {
   return (
     <div className="flex gap-2.5 min-w-0">
-      <div className="shrink-0 w-6 h-6 rounded-full flex items-center justify-center bg-danger-subtle mt-1">
-        <AlertCircle className="h-3.5 w-3.5 text-danger" />
-      </div>
+      <button type="button" onClick={() => onClickAgent?.(agent)} className="shrink-0 cursor-pointer">
+        <div className="w-6 h-6 rounded-full flex items-center justify-center bg-danger-subtle mt-1">
+          <AlertCircle className="h-3.5 w-3.5 text-danger" />
+        </div>
+      </button>
       <div className="min-w-0 flex-1">
         <div className="text-[11px] text-danger font-mono mb-0.5">{agent}</div>
         <div className="rounded-lg border border-danger/20 bg-danger-subtle/20 px-3 py-2">
@@ -2293,44 +2328,277 @@ function AgentLeftPanel({
 }
 
 /* ================================================================== */
+/*  RECIPIENT SEARCH — dark search box for @agent / #tag               */
+/* ================================================================== */
+
+/** Max pills to show before collapsing to "+N" */
+const MAX_VISIBLE_PILLS = 6
+
+function recipientLabel(r: RecipientEntry): string {
+  return r.type === "all" ? "@all" : r.type === "agent" ? `@${r.value}` : `#${r.value}`
+}
+
+function recipientKey(r: RecipientEntry): string {
+  return r.type === "all" ? "all" : `${r.type}-${r.value}`
+}
+
+function RecipientSearchBox({
+  agents,
+  allTags,
+  recipients,
+  onAddRecipient,
+  onRemoveRecipient,
+}: {
+  agents: FakeAgent[]
+  allTags: string[]
+  recipients: RecipientEntry[]
+  onAddRecipient: (entry: RecipientEntry) => void
+  onRemoveRecipient: (index: number) => void
+}) {
+  const [inputValue, setInputValue] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+  const measureRef = useRef<HTMLSpanElement>(null)
+
+  // Ghost suggestion — includes @all as a special option
+  const ghost = useMemo(() => {
+    if (!inputValue) return null
+    if (inputValue.startsWith("@")) {
+      const partial = inputValue.slice(1).toLowerCase()
+      if (!partial) return null
+      if ("all".startsWith(partial) && "all" !== partial) return "all".slice(partial.length)
+      if ("all" === partial) return null
+      const match = agents.find(a => a.name.toLowerCase().startsWith(partial))
+      if (match && match.name.toLowerCase() !== partial) return match.name.slice(partial.length)
+      if (match && match.name.toLowerCase() === partial) return null
+    }
+    if (inputValue.startsWith("#")) {
+      const partial = inputValue.slice(1).toLowerCase()
+      if (!partial) return null
+      const match = allTags.find(t => t.toLowerCase().startsWith(partial))
+      if (match && match.toLowerCase() !== partial) return match.slice(partial.length)
+      if (match && match.toLowerCase() === partial) return null
+    }
+    return null
+  }, [inputValue, agents, allTags])
+
+  const isCompleteMatch = useMemo(() => {
+    if (inputValue.startsWith("@")) {
+      const name = inputValue.slice(1).toLowerCase()
+      if (name === "all") return true
+      return agents.some(a => a.name.toLowerCase() === name)
+    }
+    if (inputValue.startsWith("#")) {
+      const tag = inputValue.slice(1).toLowerCase()
+      return allTags.some(t => t.toLowerCase() === tag)
+    }
+    return false
+  }, [inputValue, agents, allTags])
+
+  const commitInput = useCallback(() => {
+    if (inputValue.startsWith("@")) {
+      const name = inputValue.slice(1).toLowerCase()
+      if (name === "all") { onAddRecipient({ type: "all" }); setInputValue(""); return true }
+      const match = agents.find(a => a.name.toLowerCase() === name)
+      if (match) { onAddRecipient({ type: "agent", value: match.name }); setInputValue(""); return true }
+    }
+    if (inputValue.startsWith("#")) {
+      const tag = inputValue.slice(1).toLowerCase()
+      const match = allTags.find(t => t.toLowerCase() === tag)
+      if (match) { onAddRecipient({ type: "tag", value: match }); setInputValue(""); return true }
+    }
+    return false
+  }, [inputValue, agents, allTags, onAddRecipient])
+
+  const acceptGhost = useCallback(() => {
+    if (!ghost) return false
+    setInputValue(prev => prev + ghost)
+    return true
+  }, [ghost])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.key === "Tab" || e.key === "ArrowRight") && ghost) {
+      e.preventDefault()
+      acceptGhost()
+      return
+    }
+    if ((e.key === "Enter" || e.key === " ") && isCompleteMatch) {
+      e.preventDefault()
+      commitInput()
+      return
+    }
+    if (e.key === "Backspace" && inputValue === "" && recipients.length > 0) {
+      e.preventDefault()
+      onRemoveRecipient(recipients.length - 1)
+      return
+    }
+    if (e.key === "Escape") {
+      e.preventDefault()
+      setInputValue("")
+    }
+  }, [ghost, isCompleteMatch, inputValue, recipients.length, acceptGhost, commitInput, onRemoveRecipient])
+
+  // Autocomplete suggestions
+  const suggestions = useMemo((): RecipientEntry[] => {
+    if (!inputValue) return []
+    if (inputValue.startsWith("@")) {
+      const partial = inputValue.slice(1).toLowerCase()
+      const results: RecipientEntry[] = []
+      if (!partial || "all".startsWith(partial)) {
+        if (!recipients.some(r => r.type === "all")) results.push({ type: "all" })
+      }
+      agents
+        .filter(a => !partial || a.name.toLowerCase().startsWith(partial))
+        .filter(a => !recipients.some(r => r.type === "agent" && r.value === a.name))
+        .slice(0, 6)
+        .forEach(a => results.push({ type: "agent", value: a.name }))
+      return results
+    }
+    if (inputValue.startsWith("#")) {
+      const partial = inputValue.slice(1).toLowerCase()
+      return allTags
+        .filter(t => !partial || t.toLowerCase().startsWith(partial))
+        .filter(t => !recipients.some(r => r.type === "tag" && r.value === t))
+        .slice(0, 6)
+        .map(t => ({ type: "tag", value: t }))
+    }
+    return []
+  }, [inputValue, agents, allTags, recipients])
+
+  return (
+    <div className="flex flex-col min-w-0 flex-1">
+      {/* Dark search input */}
+      <div className="relative flex items-center min-w-0 rounded-md bg-surface-sunken/50 px-2 py-1">
+        <span
+          ref={measureRef}
+          className="invisible absolute whitespace-pre text-[11px] font-mono"
+          aria-hidden
+        >
+          {inputValue}
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="@agent or #tag"
+          className="bg-transparent border-none outline-none text-[11px] font-mono text-default placeholder:text-muted/30 w-full min-w-0"
+        />
+        {ghost && (
+          <span
+            className="absolute pointer-events-none text-[11px] font-mono text-muted/25 whitespace-pre"
+            style={{ left: `calc(0.5rem + ${measureRef.current?.offsetWidth ?? 0}px)` }}
+          >
+            {ghost}
+          </span>
+        )}
+      </div>
+
+      {/* Autocomplete suggestions */}
+      {suggestions.length > 0 && (
+        <div className="flex items-center gap-1 mt-1 overflow-x-auto no-scrollbar">
+          {suggestions.map(s => (
+            <button
+              key={recipientKey(s)}
+              type="button"
+              onClick={() => { onAddRecipient(s); setInputValue("") }}
+              className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-mono bg-surface-sunken text-secondary hover:bg-surface-sunken/80 hover:text-default transition-colors"
+            >
+              {recipientLabel(s)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ================================================================== */
 /*  COMPOSER BAR                                                       */
 /* ================================================================== */
 
-/**
- * Composer bar — main feed message input.
- * Broadcasts to all agents by default, use @agent to target one.
- * Individual agent messaging happens in the right panel's mini-composer.
- */
-function ComposerBar() {
+function ComposerBar({
+  recipients,
+  agents,
+  allTags,
+  onAddRecipient,
+  onRemoveRecipient,
+}: {
+  recipients: RecipientEntry[]
+  agents: FakeAgent[]
+  allTags: string[]
+  onAddRecipient: (entry: RecipientEntry) => void
+  onRemoveRecipient: (index: number) => void
+}) {
+  const placeholderName = recipients.length === 0
+    ? "your team"
+    : recipients.length === 1
+      ? recipients[0].type === "all" ? "all agents" : recipients[0].type === "agent" ? recipients[0].value : `#${recipients[0].value}`
+      : `${recipients.length} recipients`
+  const placeholder = `Message ${placeholderName}...`
+
+  const visiblePills = recipients.slice(0, MAX_VISIBLE_PILLS)
+  const overflowCount = Math.max(0, recipients.length - MAX_VISIBLE_PILLS)
+
+  // Hide "To:" line when it's just the default @team-lead
+  const isDefault = recipients.length === 1 && recipients[0].type === "agent" && recipients[0].value === "team-lead"
+
   return (
     <div className="px-6 pb-4 pt-2 max-w-3xl mx-auto w-full shrink-0">
+      {/* To: pills row — hidden when just the default recipient */}
+      {!isDefault && <div className="flex items-center gap-1.5 px-1 pb-1.5 min-w-0 overflow-x-auto no-scrollbar">
+        <span className="text-[10px] text-muted/50 font-medium shrink-0">To:</span>
+        {visiblePills.map((r, i) => (
+          <span
+            key={recipientKey(r)}
+            className="inline-flex items-center gap-1 pl-2 pr-1.5 py-0.5 rounded-full bg-surface-sunken text-[10px] font-mono text-secondary shrink-0"
+          >
+            {recipientLabel(r)}
+            <button
+              type="button"
+              onClick={() => onRemoveRecipient(i)}
+              className="text-muted/40 hover:text-muted transition-colors"
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </span>
+        ))}
+        {overflowCount > 0 && (
+          <span className="text-[10px] text-muted font-mono shrink-0">+{overflowCount}</span>
+        )}
+      </div>}
+
+      {/* Composer box */}
       <div className="relative rounded-2xl border-[0.5px] border-border-default bg-surface-raised/60 focus-within:bg-surface-raised focus-within:border-border-default">
         {/* Text input */}
         <textarea
-          placeholder="Message your team... (type @ to target an agent)"
+          placeholder={placeholder}
           rows={1}
           className="w-full bg-transparent border-none outline-none resize-none px-4 pt-4 pb-2 text-sm text-default placeholder:text-muted min-h-[52px] max-h-[40vh]"
         />
 
         {/* Toolbar row */}
-        <div className="flex items-center justify-between px-3 pb-3">
+        <div className="flex items-center justify-between px-3 pb-3 gap-2">
           {/* Left side */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
             <button
               type="button"
               disabled
-              className="rounded-lg p-1.5 text-muted cursor-not-allowed opacity-50"
+              className="rounded-lg p-1.5 text-muted cursor-not-allowed opacity-50 shrink-0"
             >
-              <Plus className="h-4 w-4" />
+              <Paperclip className="h-4 w-4" />
             </button>
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium text-muted">
-              <Users className="h-3 w-3" />
-              All agents
-            </span>
+            <RecipientSearchBox
+              agents={agents}
+              allTags={allTags}
+              recipients={recipients}
+              onAddRecipient={onAddRecipient}
+              onRemoveRecipient={onRemoveRecipient}
+            />
           </div>
 
           {/* Right side */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 shrink-0">
             <span className="text-xs text-muted font-mono tabular-nums">$0.30</span>
             <button
               type="button"
@@ -2346,6 +2614,112 @@ function ComposerBar() {
 }
 
 /* ================================================================== */
+/*  PINNED ITEM CARD — shows pending plan/permission at feed top       */
+/* ================================================================== */
+
+function PinnedItemCard({
+  item,
+  feedIndex,
+  onResolvePermission,
+  onResolvePlan,
+}: {
+  item: PendingItem
+  feedIndex: number
+  onResolvePermission: (feedIndex: number, verdict: "allowed" | "denied") => void
+  onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
+}) {
+  return (
+    <div className="px-6 pt-3 pb-1 max-w-3xl mx-auto w-full shrink-0">
+      <div className="rounded-lg border border-warning/25 bg-warning-subtle/5 p-3 border-t-2 border-t-warning/40">
+        {item.type === "plan" ? (
+          <div className="space-y-2">
+            <div className="text-[11px] text-warning font-mono">{item.agent} · Proposing a plan</div>
+            <p className="text-sm font-medium text-default">{item.title}</p>
+            <div className="space-y-1.5">
+              {item.steps.map((step, i) => (
+                <div key={i} className="flex items-start gap-2">
+                  {step.status === "done" ? (
+                    <Check className="h-3.5 w-3.5 text-success shrink-0 mt-0.5" strokeWidth={2.5} />
+                  ) : step.status === "current" ? (
+                    <span className="h-3.5 w-3.5 flex items-center justify-center shrink-0 mt-0.5">
+                      <span className="h-2 w-2 rounded-full bg-warning animate-breathe" />
+                    </span>
+                  ) : (
+                    <span className="h-3.5 w-3.5 rounded-full border border-border-default shrink-0 mt-0.5" />
+                  )}
+                  <span className={cn(
+                    "text-xs leading-tight",
+                    step.status === "done" && "text-muted line-through",
+                    step.status === "current" && "text-default font-medium",
+                    step.status === "pending" && "text-muted",
+                  )}>
+                    {step.text}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => onResolvePlan(feedIndex, "approved")}
+                className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
+              >
+                Approve
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => onResolvePlan(feedIndex, "rejected")}
+                className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
+              >
+                Reject
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <div className="text-[11px] text-info font-mono">
+              <Shield className="inline h-3 w-3 mr-1" />
+              {item.agent} · Requesting permission
+            </div>
+            <div className="rounded-md bg-surface-sunken/60 border border-border-subtle px-3 py-2">
+              <code className="text-xs font-mono text-default">{item.command}</code>
+            </div>
+            {item.risk && (
+              <div className="flex items-center gap-1.5">
+                <AlertTriangle className="h-3 w-3 text-warning shrink-0" />
+                <span className="text-[11px] text-warning">{item.risk}</span>
+              </div>
+            )}
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => onResolvePermission(feedIndex, "allowed")}
+                className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
+              >
+                Allow
+              </button>
+              <button
+                type="button"
+                onClick={() => onResolvePermission(feedIndex, "denied")}
+                className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
+              >
+                Deny
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================== */
 /*  ATTENTION BAR                                                      */
 /* ================================================================== */
 
@@ -2355,12 +2729,14 @@ function AttentionBar({
   agents,
   onResolvePermission,
   onResolvePlan,
+  onReviewAgent,
 }: {
   feedItems: TeamFeedItem[]
   focusedAgentId: string | null
   agents: FakeAgent[]
   onResolvePermission: (feedIndex: number, verdict: "allowed" | "denied") => void
   onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
+  onReviewAgent: (agentName: string) => void
 }) {
   // Collect pending items with their original feed index for resolution
   const pending: { item: PendingItem; feedIndex: number; agentId?: string }[] = []
@@ -2393,7 +2769,7 @@ function AttentionBar({
   const hasNext = clamped < sorted.length - 1
 
   return (
-    <div className="mx-6 mb-2 rounded-lg border border-warning/20 bg-warning-subtle/10 p-3 max-w-3xl self-center w-full">
+    <div className="px-6 mb-2 max-w-3xl mx-auto w-full"><div className="rounded-lg border border-warning/20 bg-warning-subtle/10 p-3">
       {/* Header: icon + count + stepper nav */}
       <div className="flex items-center gap-2 mb-2">
         <AlertTriangle className="h-3.5 w-3.5 text-warning shrink-0" />
@@ -2443,24 +2819,54 @@ function AttentionBar({
             : `${item.agent} proposed: ${item.title}`}
         </span>
         <div className="flex items-center gap-1 shrink-0">
-          <button
-            type="button"
-            onClick={() => item.type === "permission" ? onResolvePermission(feedIndex, "allowed") : onResolvePlan(feedIndex, "approved")}
-            className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-          >
-            Allow
-          </button>
-          <button
-            type="button"
-            onClick={() => item.type === "permission" ? onResolvePermission(feedIndex, "denied") : onResolvePlan(feedIndex, "rejected")}
-            className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-          >
-            Deny
-          </button>
+          {item.type === "permission" ? (
+            <>
+              <button
+                type="button"
+                onClick={() => onResolvePermission(feedIndex, "allowed")}
+                className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+              >
+                Allow
+              </button>
+              <button
+                type="button"
+                onClick={() => onResolvePermission(feedIndex, "denied")}
+                className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+              >
+                Deny
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onReviewAgent(item.agent)}
+              className="px-2 py-1 rounded text-[10px] font-medium text-warning border border-warning/30 hover:bg-warning-subtle/40 transition-colors inline-flex items-center gap-1"
+            >
+              Review <ChevronRight className="h-2.5 w-2.5" />
+            </button>
+          )}
         </div>
       </div>
-    </div>
+    </div></div>
   )
+}
+
+/** Get the agent name from a feed item (if it has one) */
+function getFeedItemAgent(item: TeamFeedItem): string | null {
+  switch (item.type) {
+    case "summary":
+    case "status":
+    case "error":
+    case "question":
+    case "plan":
+    case "permission":
+    case "multi-question":
+      return item.agent
+    case "user":
+      return item.target ?? null
+    case "system":
+      return null
+  }
 }
 
 /* ================================================================== */
@@ -2478,11 +2884,38 @@ function AttentionBar({
 /*  messages, tool results. Those live in the right panel detail view. */
 /* ================================================================== */
 
-function TeamFeed({ feedItems }: { feedItems: TeamFeedItem[] }) {
+function TeamFeed({
+  feedItems,
+  agentFilter,
+  onClickAgent,
+}: {
+  feedItems: TeamFeedItem[]
+  agentFilter?: Set<string>
+  onClickAgent?: (agentName: string) => void
+}) {
+  const filtered = useMemo(() => {
+    let items = feedItems
+    // Filter by agent
+    if (agentFilter && agentFilter.size > 0) {
+      items = items.filter(item => {
+        const agent = getFeedItemAgent(item)
+        // System messages pass through when filtering (context)
+        if (item.type === "system") return true
+        // User messages targeted to a filtered agent pass through
+        if (item.type === "user" && item.target && agentFilter.has(item.target)) return true
+        // User messages without target pass through (broadcasts)
+        if (item.type === "user" && !item.target) return true
+        // Agent items pass if agent matches
+        return agent !== null && agentFilter.has(agent)
+      })
+    }
+    return items
+  }, [feedItems, agentFilter])
+
   return (
     <ScrollArea className="flex-1 overflow-y-auto dotted-grid">
       <div className="max-w-3xl mx-auto w-full px-6 py-4 space-y-3">
-        {feedItems.map((item, i) => {
+        {filtered.map((item, i) => {
           switch (item.type) {
             case "system":
               return <SystemMessage key={i} text={item.text} />
@@ -2498,12 +2931,13 @@ function TeamFeed({ feedItems }: { feedItems: TeamFeedItem[] }) {
                   turns={item.turns}
                   duration={item.duration}
                   isError={item.isError}
+                  onClickAgent={onClickAgent}
                 />
               )
             case "status":
-              return <AgentStatusLine key={i} agent={item.agent} from={item.from} to={item.to} />
+              return <AgentStatusLine key={i} agent={item.agent} from={item.from} to={item.to} onClickAgent={onClickAgent} />
             case "error":
-              return <TeamErrorAlert key={i} agent={item.agent} text={item.text} />
+              return <TeamErrorAlert key={i} agent={item.agent} text={item.text} onClickAgent={onClickAgent} />
             case "question":
               return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
             case "plan":
@@ -3248,7 +3682,7 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
 /*  SKILLS PANEL — skills tab content in left panel                    */
 /* ================================================================== */
 
-function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
+function SkillsPanel({ allExpanded, onToggleExpandAll }: { allExpanded: boolean; onToggleExpandAll?: () => void }) {
   const [search, setSearch] = useState("")
   const [expandedSkills, setExpandedSkills] = useState<Set<string>>(new Set())
   const [showCreate, setShowCreate] = useState(false)
@@ -3366,6 +3800,20 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
           <Plus className="h-3 w-3" />
           Create
         </button>
+        {onToggleExpandAll && (
+          <button
+            type="button"
+            onClick={onToggleExpandAll}
+            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors shrink-0"
+            title={allExpanded ? "Collapse all" : "Expand all"}
+          >
+            {allExpanded ? (
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
       </div>
 
       {/* Create form */}
@@ -3877,6 +4325,8 @@ export default function PrototypePage() {
   const [focusedAgentId, setFocusedAgentId] = useState<string | null>("1")
   const [mainTab, setMainTab] = useState<"chat" | "agents" | "skills">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
+  const [mobileSkillsExpanded, setMobileSkillsExpanded] = useState(false)
+  const [recipients, setRecipients] = useState<RecipientEntry[]>([{ type: "agent", value: "team-lead" }])
   const [agentPanelOpen, setAgentPanelOpen] = useState(() => bp !== "S" && bp !== "mobile")
   const [leftPanelWidth, setLeftPanelWidth] = useState<number | null>(null)
 
@@ -3938,6 +4388,67 @@ export default function PrototypePage() {
 
   // Attention badge count for small-screen tab bar
   const pendingCount = useMemo(() => getAllPendingItems(feedItems).length, [feedItems])
+
+  // Expand recipients to flat set of agent names (tags resolve to their agents)
+  // @all = no filter (empty set means all pass through)
+  const effectiveAgentFilter = useMemo(() => {
+    if (recipients.some(r => r.type === "all")) return new Set<string>()
+    if (recipients.length === 0) return new Set<string>()
+    const names = new Set<string>()
+    for (const r of recipients) {
+      if (r.type === "agent") names.add(r.value)
+      else if (r.type === "tag") for (const a of agents) { if (a.tags.includes(r.value)) names.add(a.name) }
+    }
+    return names
+  }, [recipients, agents])
+
+  const singleFilteredAgent = useMemo(() =>
+    effectiveAgentFilter.size === 1 ? Array.from(effectiveAgentFilter)[0] : null
+  , [effectiveAgentFilter])
+
+  const pinnedItem = useMemo(() => {
+    if (!singleFilteredAgent) return null
+    const pending = getPendingItemsForAgent(feedItems, singleFilteredAgent)
+    if (pending.length === 0) return null
+    const feedIndex = feedItems.indexOf(pending[0])
+    return { item: pending[0], feedIndex }
+  }, [singleFilteredAgent, feedItems])
+
+  // Recipient handlers
+  const defaultRecipient: RecipientEntry = { type: "agent", value: "team-lead" }
+
+  const handleAddRecipient = useCallback((entry: RecipientEntry) => {
+    setRecipients(prev => {
+      // @all replaces everything
+      if (entry.type === "all") return [entry]
+      // Adding a specific recipient removes @all
+      const without = prev.filter(r => r.type !== "all")
+      const entryKey = `${entry.type}:${"value" in entry ? entry.value : ""}`
+      const isDupe = without.some(r => `${r.type}:${"value" in r ? r.value : ""}` === entryKey)
+      if (isDupe) return without
+      return [...without, entry]
+    })
+  }, [])
+
+  const handleRemoveRecipient = useCallback((index: number) => {
+    setRecipients(prev => {
+      const next = prev.filter((_, i) => i !== index)
+      // If removing last recipient, reset to default
+      if (next.length === 0) return [defaultRecipient]
+      return next
+    })
+  }, [])
+
+  const handleReviewAgent = useCallback((agentName: string) => {
+    setRecipients([{ type: "agent", value: agentName }])
+    setMainTab("chat")
+  }, [])
+
+  // Click agent avatar in feed → set recipient to that agent
+  const handleFeedClickAgent = useCallback((agentName: string) => {
+    setRecipients([{ type: "agent", value: agentName }])
+    setMainTab("chat")
+  }, [])
 
   // Determine what's visible at each breakpoint
   const showTopTabs = bp === "mobile"
@@ -4046,15 +4557,34 @@ export default function PrototypePage() {
         {/* Center: team feed + attention bar + composer */}
         {(!showTopTabs || mainTab === "chat") && (
           <main className="flex-1 min-w-0 flex flex-col min-h-0">
-            <TeamFeed feedItems={feedItems} />
+            {pinnedItem && (
+              <PinnedItemCard
+                item={pinnedItem.item}
+                feedIndex={pinnedItem.feedIndex}
+                onResolvePermission={handleResolvePermission}
+                onResolvePlan={handleResolvePlan}
+              />
+            )}
+            <TeamFeed
+              feedItems={feedItems}
+              agentFilter={effectiveAgentFilter}
+              onClickAgent={handleFeedClickAgent}
+            />
             <AttentionBar
               feedItems={feedItems}
               focusedAgentId={focusedAgentId}
               agents={agents}
               onResolvePermission={handleResolvePermission}
               onResolvePlan={handleResolvePlan}
+              onReviewAgent={handleReviewAgent}
             />
-            <ComposerBar />
+            <ComposerBar
+              recipients={recipients}
+              agents={agents}
+              allTags={ALL_TAGS}
+              onAddRecipient={handleAddRecipient}
+              onRemoveRecipient={handleRemoveRecipient}
+            />
           </main>
         )}
 
@@ -4076,6 +4606,7 @@ export default function PrototypePage() {
               agents={agents}
               onResolvePermission={handleResolvePermission}
               onResolvePlan={handleResolvePlan}
+              onReviewAgent={handleReviewAgent}
             />
           </div>
         )}
@@ -4083,13 +4614,14 @@ export default function PrototypePage() {
         {/* Top-tab content: skills (S + mobile) */}
         {showTopTabs && mainTab === "skills" && (
           <div className="flex-1 min-w-0 bg-surface overflow-hidden flex flex-col">
-            <SkillsPanel allExpanded={false} />
+            <SkillsPanel allExpanded={mobileSkillsExpanded} onToggleExpandAll={() => setMobileSkillsExpanded(p => !p)} />
             <AttentionBar
               feedItems={feedItems}
               focusedAgentId={focusedAgentId}
               agents={agents}
               onResolvePermission={handleResolvePermission}
               onResolvePlan={handleResolvePlan}
+              onReviewAgent={handleReviewAgent}
             />
           </div>
         )}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1401,6 +1401,7 @@ function AgentLeftPanel({
   const [tagFilter, setTagFilter] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [showTagDropdown, setShowTagDropdown] = useState(false)
+  const [skillsAllExpanded, setSkillsAllExpanded] = useState(false)
 
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
@@ -1590,7 +1591,7 @@ function AgentLeftPanel({
           Skills
         </button>
         <span className="flex-1" />
-        {panelTab === "agents" && (
+        {panelTab === "agents" ? (
           <button
             type="button"
             onClick={onToggleExpandAll}
@@ -1598,6 +1599,19 @@ function AgentLeftPanel({
             title="Cycle card states"
           >
             {expandedIds.size > 0 ? (
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setSkillsAllExpanded(p => !p)}
+            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+            title={skillsAllExpanded ? "Collapse all" : "Expand all"}
+          >
+            {skillsAllExpanded ? (
               <ChevronsDownUp className="h-3.5 w-3.5" />
             ) : (
               <ChevronsUpDown className="h-3.5 w-3.5" />
@@ -1725,7 +1739,7 @@ function AgentLeftPanel({
           </div>
         </>
       ) : (
-        <SkillsPanel />
+        <SkillsPanel allExpanded={skillsAllExpanded} />
       )}
 
       {/* Bottom toolbar: secrets + cost + user */}
@@ -1932,13 +1946,78 @@ function VncThumbnail({ agent }: { agent: FakeAgent }) {
 }
 
 /* ================================================================== */
+/*  TAG INPUT — reusable inline tag editor with autocomplete           */
+/* ================================================================== */
+
+function TagInput({
+  tags,
+  onChange,
+  placeholder = "Add tag...",
+}: {
+  tags: string[]
+  onChange: (tags: string[]) => void
+  placeholder?: string
+}) {
+  const [input, setInput] = useState("")
+
+  const addTag = (tag: string) => {
+    const normalized = tag.toLowerCase().replace(/[^a-z0-9-]/g, "")
+    if (normalized && !tags.includes(normalized)) {
+      onChange([...tags, normalized])
+    }
+    setInput("")
+  }
+
+  const removeTag = (tag: string) => {
+    onChange(tags.filter(t => t !== tag))
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent/10 border border-accent/20 text-[11px] font-mono text-accent"
+        >
+          {tag}
+          <button
+            type="button"
+            onClick={() => removeTag(tag)}
+            className="ml-0.5 text-accent/50 hover:text-accent transition-colors"
+          >
+            <X className="h-2.5 w-2.5" />
+          </button>
+        </span>
+      ))}
+      <input
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && input.trim()) {
+            e.preventDefault()
+            addTag(input.trim())
+          }
+          if (e.key === "Backspace" && !input && tags.length > 0) {
+            removeTag(tags[tags.length - 1])
+          }
+        }}
+        placeholder={tags.length === 0 ? placeholder : ""}
+        className="flex-1 min-w-[60px] bg-transparent border-none outline-none text-[11px] font-mono text-default placeholder:text-muted/40"
+      />
+    </div>
+  )
+}
+
+/* ================================================================== */
 /*  AGENT SETTINGS PANEL — config form inside expanded card            */
 /* ================================================================== */
 
 function AgentSettingsPanel({ agent }: { agent: FakeAgent }) {
   const [model, setModel] = useState(agent.model)
   const [instructions, setInstructions] = useState(agent.instructions)
-  const dirty = model !== agent.model || instructions !== agent.instructions
+  const [agentTags, setAgentTags] = useState(agent.tags)
+  const dirty = model !== agent.model || instructions !== agent.instructions || JSON.stringify(agentTags) !== JSON.stringify(agent.tags)
 
   return (
     <div className="px-3 py-3 space-y-3">
@@ -1969,6 +2048,16 @@ function AgentSettingsPanel({ agent }: { agent: FakeAgent }) {
           rows={4}
           className="w-full bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs font-mono text-default outline-none focus:border-accent/50 transition-colors resize-none"
         />
+      </div>
+
+      {/* Tags */}
+      <div>
+        <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1">
+          Tags
+        </label>
+        <div className="bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 focus-within:border-accent/50 transition-colors">
+          <TagInput tags={agentTags} onChange={setAgentTags} placeholder="Add tag..." />
+        </div>
       </div>
 
       {/* MCP Servers */}
@@ -2438,12 +2527,13 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
 /*  SKILLS PANEL — skills tab content in left panel                    */
 /* ================================================================== */
 
-function SkillsPanel() {
+function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
   const [search, setSearch] = useState("")
-  const [expandedSkill, setExpandedSkill] = useState<string | null>(null)
+  const [expandedSkills, setExpandedSkills] = useState<Set<string>>(new Set())
   const [showCreate, setShowCreate] = useState(false)
   const [newName, setNewName] = useState("")
   const [newContent, setNewContent] = useState("")
+  const [newTags, setNewTags] = useState<string[]>([])
 
   const filtered = useMemo(() => {
     if (!search.trim()) return SKILLS
@@ -2499,6 +2589,14 @@ function SkillsPanel() {
             rows={4}
             className="w-full bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs font-mono text-default placeholder:text-muted/40 outline-none focus:border-accent/50 transition-colors resize-none"
           />
+          <div>
+            <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1">
+              Assign to tags
+            </label>
+            <div className="bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 focus-within:border-accent/50 transition-colors">
+              <TagInput tags={newTags} onChange={setNewTags} placeholder="Add tag..." />
+            </div>
+          </div>
           <div className="flex justify-end">
             <button
               type="button"
@@ -2526,12 +2624,17 @@ function SkillsPanel() {
             </div>
           ) : (
             filtered.map((skill) => {
-              const isExpanded = expandedSkill === skill.id
+              const isExpanded = allExpanded || expandedSkills.has(skill.id)
               return (
                 <div key={skill.id} className="rounded-lg border border-border-subtle overflow-hidden">
                   <button
                     type="button"
-                    onClick={() => setExpandedSkill(isExpanded ? null : skill.id)}
+                    onClick={() => setExpandedSkills(prev => {
+                      const next = new Set(prev)
+                      if (next.has(skill.id)) next.delete(skill.id)
+                      else next.add(skill.id)
+                      return next
+                    })}
                     className="w-full text-left px-2.5 py-2 hover:bg-surface-raised/30 transition-colors"
                   >
                     <div className="flex items-center gap-2 min-w-0">

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -33,8 +33,6 @@ import {
   Filter,
   Tag,
   Shield,
-  FileText,
-  ChevronDown,
 } from "lucide-react"
 import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -390,7 +388,7 @@ type TeamFeedItem =
   | { type: "status"; agent: string; from: string; to: string }
   | { type: "error"; agent: string; text: string }
   | { type: "question"; agent: string; question: string; options: string[] }
-  | { type: "plan"; agent: string; title: string; context: string; steps: { text: string; description?: string; files?: string[]; status: "done" | "current" | "pending" }[]; files: string[]; planStatus: "pending" | "approved" | "rejected" }
+  | { type: "plan"; agent: string; title: string; plan: string; planStatus: "pending" | "approved" | "rejected" }
   | { type: "permission"; agent: string; command: string; risk?: string; permStatus: "pending" | "allowed" | "denied" }
   | { type: "multi-question"; agent: string; questions: { text: string; options: string[] }[] }
 
@@ -413,15 +411,27 @@ const TEAM_FEED: TeamFeedItem[] = [
     type: "plan",
     agent: "backend",
     title: "Fix JWT validation and add clock skew tolerance",
-    context: "The JWT validation middleware rejects tokens within 5s of expiry due to Date.now() returning milliseconds while the JWT exp claim uses seconds. Adding clock skew tolerance prevents intermittent 401s during server clock drift.",
-    steps: [
-      { text: "Identify expiry comparison bug", description: "Read auth.ts, trace the validateToken() path to find the ms vs seconds mismatch", files: ["backend/middleware/auth.ts"], status: "done" },
-      { text: "Convert Date.now() to seconds", description: "Replace Date.now() with Math.floor(Date.now() / 1000) in the expiry check", files: ["backend/middleware/auth.ts"], status: "done" },
-      { text: "Add 30s clock skew tolerance", description: "Pass clockTolerance: 30 to jsonwebtoken.verify() options", files: ["backend/middleware/auth.ts", "backend/config/auth.ts"], status: "current" },
-      { text: "Add structured error logging", description: "Log validation failures with token claims, expected vs actual timestamps", files: ["backend/middleware/auth.ts"], status: "pending" },
-      { text: "Run lint and existing tests", files: ["backend/tests/auth.test.ts"], status: "pending" },
-    ],
-    files: ["backend/middleware/auth.ts", "backend/config/auth.ts", "backend/tests/auth.test.ts"],
+    plan: `## Context
+
+The JWT validation middleware rejects tokens within 5s of expiry due to \`Date.now()\` returning milliseconds while the JWT \`exp\` claim uses seconds. This causes intermittent 401s during peak traffic when server clocks drift.
+
+## Changes
+
+1. **Fix the unit mismatch** — Replace \`Date.now()\` with \`Math.floor(Date.now() / 1000)\` in the expiry comparison inside \`validateToken()\`
+2. **Add clock skew tolerance** — Pass \`clockTolerance: 30\` to \`jsonwebtoken.verify()\` options, configurable via \`AUTH_CLOCK_SKEW_SECONDS\` env var
+3. **Structured error logging** — Log validation failures with token claims and expected vs actual timestamps for debugging
+
+## Files
+
+- \`backend/middleware/auth.ts\` — main fix + logging
+- \`backend/config/auth.ts\` — new \`clockTolerance\` config
+- \`backend/tests/auth.test.ts\` — new test cases for skew tolerance
+
+## Verification
+
+- Existing auth tests still pass
+- New test: token with exp = now - 25s should be accepted (within tolerance)
+- New test: token with exp = now - 35s should be rejected (outside tolerance)`,
     planStatus: "approved",
   },
 
@@ -521,13 +531,26 @@ const TEAM_FEED: TeamFeedItem[] = [
     type: "plan",
     agent: "devops",
     title: "Deploy auth fix to staging",
-    context: "The auth hotfix needs to reach staging for QA verification before the production rollout window. Build a fresh image from the fix branch, run integration tests against the staging database, then swap traffic with zero downtime.",
-    steps: [
-      { text: "Build Docker image with auth changes", description: "docker build from fix/jwt-validation branch, tag as staging-candidate", files: ["backend/Dockerfile", "docker-compose.staging.yml"], status: "done" as const },
-      { text: "Run integration tests in staging env", description: "Execute full auth test suite against staging DB with new image", files: ["tests/integration/auth.test.ts", "tests/integration/refresh.test.ts"], status: "current" as const },
-      { text: "Swap traffic to new deployment", description: "Blue-green deploy — route staging traffic to new containers, drain old ones", files: ["infra/staging/deploy.yaml", "infra/staging/routes.yaml"], status: "pending" as const },
-    ],
-    files: ["backend/Dockerfile", "docker-compose.staging.yml", "tests/integration/auth.test.ts", "tests/integration/refresh.test.ts", "infra/staging/deploy.yaml", "infra/staging/routes.yaml"],
+    plan: `## Context
+
+The auth hotfix on \`fix/jwt-validation\` needs to reach staging for QA verification before the Friday production rollout window.
+
+## Steps
+
+1. Build Docker image from \`fix/jwt-validation\` branch, tag as \`staging-candidate\`
+2. Run full auth integration test suite against staging database with new image
+3. Blue-green deploy — swap staging traffic to new containers, drain old ones within 60s grace period
+
+## Files
+
+- \`backend/Dockerfile\`
+- \`docker-compose.staging.yml\`
+- \`tests/integration/auth.test.ts\`
+- \`infra/staging/deploy.yaml\`
+
+## Rollback
+
+If integration tests fail or health checks don't pass within 120s, automatically revert to the previous deployment. No manual intervention needed.`,
     planStatus: "pending" as const,
   },
 
@@ -1112,26 +1135,18 @@ function QuestionCard({
   )
 }
 
-/** 7b. PlanCard — interactive plan approval card */
+/** 7b. PlanCard — feed notification line (no actions, review happens in pinned card) */
 function PlanCard({
   agent,
   title,
-  context,
-  steps,
-  files,
-  planStatus: initialStatus,
+  planStatus,
 }: {
   agent: string
   title: string
-  context: string
-  steps: { text: string; description?: string; files?: string[]; status: "done" | "current" | "pending" }[]
-  files: string[]
+  plan: string
   planStatus: "pending" | "approved" | "rejected"
 }) {
-  const [status, setStatus] = useState(initialStatus)
-  const [expanded, setExpanded] = useState(true)
-
-  if (status === "approved") {
+  if (planStatus === "approved") {
     return (
       <div className="flex items-center gap-2 py-0.5 justify-center">
         <AgentAvatar name={agent} size="sm" />
@@ -1142,7 +1157,7 @@ function PlanCard({
     )
   }
 
-  if (status === "rejected") {
+  if (planStatus === "rejected") {
     return (
       <div className="flex items-center gap-2 py-0.5 justify-center">
         <AgentAvatar name={agent} size="sm" />
@@ -1153,145 +1168,13 @@ function PlanCard({
     )
   }
 
-  const doneCount = steps.filter(s => s.status === "done").length
-  const totalCount = steps.length
-
+  // Pending — just a notification line, no card
   return (
-    <div className="flex gap-2 min-w-0">
-      <ChatAvatar name={agent} />
-      <div className="min-w-0 flex-1">
-        <div className="text-[11px] text-warning font-mono mb-0.5">{agent} · Proposing a plan</div>
-        <div className="rounded-lg border border-warning/20 bg-surface-raised/60 max-w-xl overflow-hidden">
-          {/* Header — title + summary + expand toggle */}
-          <div className="px-3.5 pt-3 pb-2">
-            <button
-              type="button"
-              onClick={() => setExpanded(e => !e)}
-              className="flex items-start gap-2 w-full text-left group"
-            >
-              <ChevronDown className={cn(
-                "h-3.5 w-3.5 text-muted shrink-0 mt-0.5 transition-transform",
-                !expanded && "-rotate-90",
-              )} />
-              <div className="min-w-0 flex-1">
-                <p className="text-[13px] font-medium text-default leading-snug">{title}</p>
-                <p className="text-[11px] text-muted mt-1 leading-relaxed">{context}</p>
-              </div>
-            </button>
-            {/* Progress bar */}
-            <div className="flex items-center gap-2 mt-2.5 ml-5.5">
-              <div className="flex-1 h-1 rounded-full bg-surface-sunken overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-success/60 transition-all"
-                  style={{ width: `${(doneCount / totalCount) * 100}%` }}
-                />
-              </div>
-              <span className="text-[10px] font-mono text-muted shrink-0">{doneCount}/{totalCount}</span>
-            </div>
-          </div>
-
-          {/* Expanded content — steps + files */}
-          {expanded && (
-            <>
-              {/* Steps */}
-              <div className="border-t border-border-subtle/50 px-3.5 py-2.5">
-                <div className="space-y-0.5">
-                  {steps.map((step, i) => (
-                    <div key={i} className="group/step">
-                      <div className="flex items-start gap-2.5 py-1">
-                        {/* Step number + status */}
-                        <span className={cn(
-                          "w-5 h-5 rounded-md flex items-center justify-center shrink-0 text-[10px] font-mono font-medium",
-                          step.status === "done" && "bg-success/15 text-success",
-                          step.status === "current" && "bg-warning/15 text-warning",
-                          step.status === "pending" && "bg-surface-sunken text-muted",
-                        )}>
-                          {step.status === "done" ? (
-                            <Check className="h-3 w-3" strokeWidth={2.5} />
-                          ) : (
-                            i + 1
-                          )}
-                        </span>
-                        {/* Step text + description */}
-                        <div className="min-w-0 flex-1">
-                          <span className={cn(
-                            "text-xs leading-snug block",
-                            step.status === "done" && "text-muted",
-                            step.status === "current" && "text-default font-medium",
-                            step.status === "pending" && "text-secondary",
-                          )}>
-                            {step.text}
-                          </span>
-                          {step.description && (
-                            <span className="text-[10px] text-muted/70 leading-relaxed block mt-0.5">
-                              {step.description}
-                            </span>
-                          )}
-                          {step.files && step.files.length > 0 && (
-                            <div className="flex flex-wrap gap-1 mt-1">
-                              {step.files.map(f => (
-                                <span key={f} className="inline-flex items-center gap-0.5 text-[9px] font-mono text-muted/60 bg-surface-sunken/60 rounded px-1.5 py-0.5">
-                                  <FileText className="h-2.5 w-2.5" />
-                                  {f.split("/").pop()}
-                                </span>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                      {/* Connector line between steps */}
-                      {i < steps.length - 1 && (
-                        <div className="ml-2.5 w-px h-1 bg-border-subtle/40" />
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Files affected */}
-              {files.length > 0 && (
-                <div className="border-t border-border-subtle/50 px-3.5 py-2">
-                  <div className="flex items-center gap-1.5 mb-1.5">
-                    <FileText className="h-3 w-3 text-muted/60" />
-                    <span className="text-[10px] font-mono text-muted/60 uppercase tracking-wider">Files affected</span>
-                  </div>
-                  <div className="flex flex-wrap gap-1">
-                    {files.map(f => (
-                      <span key={f} className="text-[10px] font-mono text-secondary/80 bg-surface-sunken/40 rounded px-1.5 py-0.5">
-                        {f}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-
-          {/* Actions */}
-          <div className="border-t border-border-subtle/50 px-3.5 py-2.5 flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setStatus("approved")}
-              className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
-            >
-              Approve
-            </button>
-            <button
-              type="button"
-              className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
-            >
-              Edit
-            </button>
-            <button
-              type="button"
-              onClick={() => setStatus("rejected")}
-              className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
-            >
-              Reject
-            </button>
-          </div>
-        </div>
-      </div>
+    <div className="flex items-center gap-2 py-0.5 justify-center">
+      <AgentAvatar name={agent} size="sm" />
+      <span className="text-[10px] font-mono text-warning">
+        Plan: {title} · awaiting review
+      </span>
     </div>
   )
 }
@@ -2738,96 +2621,21 @@ function PinnedPlanContent({
   feedIndex: number
   onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
 }) {
-  const doneCount = item.steps.filter(s => s.status === "done").length
-  const totalCount = item.steps.length
-
   return (
     <div>
       {/* Header */}
-      <div className="px-3.5 pt-3 pb-2">
-        <div className="text-[11px] text-warning font-mono mb-1.5">{item.agent} · Proposing a plan</div>
+      <div className="px-3.5 pt-3 pb-1">
+        <div className="text-[11px] text-warning font-mono mb-1">{item.agent} · Proposing a plan</div>
         <p className="text-[13px] font-medium text-default leading-snug">{item.title}</p>
-        <p className="text-[11px] text-muted mt-1 leading-relaxed">{item.context}</p>
-        {/* Progress bar */}
-        <div className="flex items-center gap-2 mt-2.5">
-          <div className="flex-1 h-1 rounded-full bg-surface-sunken overflow-hidden">
-            <div
-              className="h-full rounded-full bg-success/60 transition-all"
-              style={{ width: `${(doneCount / totalCount) * 100}%` }}
-            />
-          </div>
-          <span className="text-[10px] font-mono text-muted shrink-0">{doneCount}/{totalCount}</span>
-        </div>
       </div>
 
-      {/* Steps */}
-      <div className="border-t border-border-subtle/50 px-3.5 py-2.5">
-        <div className="space-y-0.5">
-          {item.steps.map((step, i) => (
-            <div key={i}>
-              <div className="flex items-start gap-2.5 py-1">
-                <span className={cn(
-                  "w-5 h-5 rounded-md flex items-center justify-center shrink-0 text-[10px] font-mono font-medium",
-                  step.status === "done" && "bg-success/15 text-success",
-                  step.status === "current" && "bg-warning/15 text-warning",
-                  step.status === "pending" && "bg-surface-sunken text-muted",
-                )}>
-                  {step.status === "done" ? (
-                    <Check className="h-3 w-3" strokeWidth={2.5} />
-                  ) : (
-                    i + 1
-                  )}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <span className={cn(
-                    "text-xs leading-snug block",
-                    step.status === "done" && "text-muted",
-                    step.status === "current" && "text-default font-medium",
-                    step.status === "pending" && "text-secondary",
-                  )}>
-                    {step.text}
-                  </span>
-                  {step.description && (
-                    <span className="text-[10px] text-muted/70 leading-relaxed block mt-0.5">
-                      {step.description}
-                    </span>
-                  )}
-                  {step.files && step.files.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {step.files.map(f => (
-                        <span key={f} className="inline-flex items-center gap-0.5 text-[9px] font-mono text-muted/60 bg-surface-sunken/60 rounded px-1.5 py-0.5">
-                          <FileText className="h-2.5 w-2.5" />
-                          {f.split("/").pop()}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-              {i < item.steps.length - 1 && (
-                <div className="ml-2.5 w-px h-1 bg-border-subtle/40" />
-              )}
-            </div>
-          ))}
-        </div>
+      {/* Plan markdown */}
+      <div className="border-t border-border-subtle/50 px-3.5 py-3">
+        <MarkdownRenderer
+          content={item.plan}
+          className="text-xs text-secondary [&_h2]:text-[11px] [&_h2]:font-mono [&_h2]:uppercase [&_h2]:tracking-wider [&_h2]:text-muted [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:first:mt-0 [&_ol]:space-y-1 [&_ul]:space-y-0.5 [&_li]:text-xs [&_li]:leading-relaxed [&_code]:text-[10px] [&_code]:bg-surface-sunken/60 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_p]:leading-relaxed [&_p]:mb-1.5"
+        />
       </div>
-
-      {/* Files affected */}
-      {item.files.length > 0 && (
-        <div className="border-t border-border-subtle/50 px-3.5 py-2">
-          <div className="flex items-center gap-1.5 mb-1.5">
-            <FileText className="h-3 w-3 text-muted/60" />
-            <span className="text-[10px] font-mono text-muted/60 uppercase tracking-wider">Files affected</span>
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {item.files.map(f => (
-              <span key={f} className="text-[10px] font-mono text-secondary/80 bg-surface-sunken/40 rounded px-1.5 py-0.5">
-                {f}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
 
       {/* Actions */}
       <div className="border-t border-border-subtle/50 px-3.5 py-2.5 flex items-center gap-2">
@@ -2837,12 +2645,6 @@ function PinnedPlanContent({
           className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
         >
           Approve
-        </button>
-        <button
-          type="button"
-          className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
-        >
-          Edit
         </button>
         <button
           type="button"
@@ -3132,7 +2934,7 @@ function TeamFeed({
             case "question":
               return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
             case "plan":
-              return <PlanCard key={i} agent={item.agent} title={item.title} context={item.context} steps={item.steps} files={item.files} planStatus={item.planStatus} />
+              return <PlanCard key={i} agent={item.agent} title={item.title} plan={item.plan} planStatus={item.planStatus} />
             case "permission":
               return <PermissionCard key={i} agent={item.agent} command={item.command} risk={item.risk} permStatus={item.permStatus} />
             case "multi-question":

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -3942,6 +3942,40 @@ export default function PrototypePage() {
 
       {/* Right side: tabs (on small) + team feed */}
       <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
+        {/* Mobile header: project + secrets + user (replaces sidebar header/footer) */}
+        {bp === "mobile" && (
+          <div className="h-10 px-3 flex items-center border-b border-border-default bg-surface shrink-0">
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 px-1 py-1 -ml-1 rounded-md hover:bg-surface-sunken/40 transition-colors min-w-0"
+            >
+              <div className="h-6 w-6 rounded-md bg-accent/15 flex items-center justify-center text-[11px] font-bold text-accent shrink-0">
+                A
+              </div>
+              <span className="text-sm font-medium text-default truncate">agentobox</span>
+              <ChevronRight size={12} className="text-muted/40 rotate-90 shrink-0" />
+            </button>
+            <span className="flex-1" />
+            <button
+              type="button"
+              onClick={() => setSecretsOpen(true)}
+              className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+              title="Project secrets"
+            >
+              <KeyRound className="h-3.5 w-3.5" />
+            </button>
+            <span className="text-[10px] text-muted/60 font-mono tabular-nums mx-1.5">
+              {formatCost(agents.reduce((s, a) => s + a.cost, 0))}
+            </span>
+            <div
+              className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
+              title="vahid"
+            >
+              V
+            </div>
+          </div>
+        )}
+
         {/* Top tabs (S + mobile) */}
         {showTopTabs && (
           <TabBar

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -6,11 +6,12 @@ import {
   Users,
   MessageSquare,
   ChevronRight,
+  ChevronLeft,
   Check,
   X,
   AlertCircle,
   Plus,
-  Terminal,
+
   Clock,
   DollarSign,
   RotateCcw,
@@ -1201,25 +1202,256 @@ function SecretsModal({
 }
 
 /* ================================================================== */
-/*  HEADER BAR                                                         */
+/*  FLEET HEALTH PILLS                                                 */
 /* ================================================================== */
 
-function HeaderBar({
-  onOpenSecrets,
-  selectedAgent,
-  agents,
+function FleetHealthPills({
+  statusCounts,
+  layout,
 }: {
-  onOpenSecrets: () => void
-  selectedAgent: FakeAgent | null
-  agents: FakeAgent[]
+  statusCounts: Record<string, number>
+  layout: "vertical" | "horizontal"
 }) {
-  const totalCost = agents.reduce((sum, a) => sum + a.cost, 0)
+  const pills = PILL_CONFIG.filter((p) => (statusCounts[p.key] ?? 0) > 0)
+
+  if (pills.length === 0) return null
 
   return (
-    <div className="h-12 border-b border-border-default bg-surface-sunken px-4 flex items-center gap-4 shrink-0">
-      {/* Left: project name + secrets */}
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-default">agentobox</span>
+    <div
+      className={cn(
+        "flex items-center gap-1",
+        layout === "vertical" ? "flex-col" : "flex-row gap-2",
+      )}
+    >
+      {pills.map((pill) => (
+        <span
+          key={pill.key}
+          className={cn(
+            "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
+            pill.text,
+          )}
+        >
+          <span
+            className={cn(
+              "h-1.5 w-1.5 rounded-full shrink-0",
+              pill.dot,
+              pill.animate && "animate-breathe text-success",
+            )}
+          />
+          {statusCounts[pill.key]}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/* ================================================================== */
+/*  AGENT LEFT PANEL — unified icon rail + agent cards                 */
+/* ================================================================== */
+
+function AgentLeftPanel({
+  agents,
+  cardStates,
+  onSelectAgent,
+  onToggleExpandAll,
+  onOpenSecrets,
+  isOpen,
+  onToggleOpen,
+  width,
+  onResize,
+  onResetWidth,
+}: {
+  agents: FakeAgent[]
+  cardStates: Record<string, CardState>
+  onSelectAgent: (id: string) => void
+  onToggleExpandAll: () => void
+  onOpenSecrets: () => void
+  isOpen: boolean
+  onToggleOpen: () => void
+  width: number
+  onResize: (delta: number) => void
+  onResetWidth: () => void
+}) {
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
+    for (const a of agents) counts[a.status] = (counts[a.status] ?? 0) + 1
+    return counts
+  }, [agents])
+
+  const totalCost = useMemo(() => agents.reduce((sum, a) => sum + a.cost, 0), [agents])
+
+  /* ---- Collapsed state: 48px icon rail ---- */
+  if (!isOpen) {
+    return (
+      <aside className="group/rail w-12 h-full bg-surface-sunken border-r-[0.5px] border-border-default flex flex-col shrink-0 relative">
+        {/* Hover edge hint — subtle accent line on right edge */}
+        <div className="absolute top-0 bottom-0 right-0 w-px bg-transparent group-hover/rail:bg-accent/25 transition-colors" />
+
+        {/* Project initial */}
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          className="pt-3 pb-2 flex justify-center hover:bg-surface-raised/30 transition-colors"
+          title="Open panel"
+        >
+          <div className="h-6 w-6 rounded-md bg-accent/15 flex items-center justify-center text-[11px] font-bold text-accent">
+            A
+          </div>
+        </button>
+
+        {/* Agent avatars */}
+        <div className="flex-1 flex flex-col items-center gap-1.5 py-2 overflow-y-auto">
+          {agents.map((agent) => {
+            const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
+            const isSelected = (cardStates[agent.id] ?? "collapsed") !== "collapsed"
+            const isRunning = agent.status === "running"
+            const isStopped = agent.status === "stopped"
+
+            return (
+              <button
+                key={agent.id}
+                type="button"
+                onClick={() => {
+                  onSelectAgent(agent.id)
+                  onToggleOpen()
+                }}
+                className={cn(
+                  "relative group",
+                  isStopped && "opacity-55",
+                )}
+                title={agent.name}
+              >
+                <AgentAvatar name={agent.name} size="md" stopped={isStopped} />
+                <span
+                  className={cn(
+                    "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface-sunken",
+                    config.dot,
+                    isRunning && "animate-breathe text-success",
+                  )}
+                />
+                {isSelected && (
+                  <span className="absolute inset-0 rounded-md ring-2 ring-accent/50" />
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Fleet health */}
+        <div className="py-2 flex flex-col items-center gap-1 border-t border-border-subtle">
+          <FleetHealthPills statusCounts={statusCounts} layout="vertical" />
+        </div>
+
+        {/* Expand button — explicit affordance */}
+        <div className="flex justify-center py-1.5 border-t border-border-subtle">
+          <button
+            type="button"
+            onClick={onToggleOpen}
+            className="p-1 rounded-md text-muted/40 hover:text-accent hover:bg-accent/10 transition-colors"
+            title="Expand panel"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        {/* Bottom: secrets + cost + user avatar */}
+        <div className="py-2 flex flex-col items-center gap-2 border-t border-border-default">
+          <button
+            type="button"
+            onClick={onOpenSecrets}
+            className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+            title="Project secrets"
+          >
+            <KeyRound className="h-3.5 w-3.5" />
+          </button>
+          <span className="text-[9px] text-muted/60 font-mono tabular-nums">
+            {formatCost(totalCost)}
+          </span>
+          <div
+            className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
+            title="vahid"
+          >
+            V
+          </div>
+        </div>
+      </aside>
+    )
+  }
+
+  /* ---- Open state: resizable panel ---- */
+  return (
+    <aside
+      className="relative h-full bg-surface border-r border-border-default flex flex-col shrink-0"
+      style={{ width, minWidth: width }}
+    >
+      <ResizeHandle onResize={onResize} onReset={onResetWidth} side="right" />
+
+      {/* Project selector placeholder */}
+      <div className="h-10 px-3 flex items-center border-b border-border-default shrink-0">
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 px-1 py-1 -ml-1 rounded-md hover:bg-surface-sunken/40 transition-colors"
+        >
+          <div className="h-6 w-6 rounded-md bg-accent/15 flex items-center justify-center text-[11px] font-bold text-accent shrink-0">
+            A
+          </div>
+          <span className="text-sm font-medium text-default">agentobox</span>
+          <ChevronRight size={12} className="text-muted/40 rotate-90 shrink-0" />
+        </button>
+      </div>
+
+      {/* Panel header: title + expand-all + collapse */}
+      <div className="h-8 px-3 flex items-center gap-2 border-b border-border-default shrink-0">
+        <Users className="h-3.5 w-3.5 text-muted" />
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted flex-1">
+          Agents
+        </span>
+        <button
+          type="button"
+          onClick={onToggleExpandAll}
+          className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+          title="Cycle card states"
+        >
+          {Object.values(cardStates).some((s) => s === "expanded") ? (
+            <ChevronsDownUp className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronsUpDown className="h-3.5 w-3.5" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+          title="Collapse panel"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Agent cards */}
+      <ScrollArea className="flex-1 overflow-y-auto">
+        <div className="p-3 space-y-2">
+          {agents.map((agent) => (
+            <AgentCardRow
+              key={agent.id}
+              agent={agent}
+              cardState={cardStates[agent.id] ?? "collapsed"}
+              onSelect={() => onSelectAgent(agent.id)}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+
+      {/* Fleet health horizontal */}
+      <div className="px-3 py-1.5 border-t border-border-subtle flex items-center gap-2">
+        <FleetHealthPills statusCounts={statusCounts} layout="horizontal" />
+        <span className="text-[9px] text-muted/40 font-mono ml-auto">
+          {agents.length} agents
+        </span>
+      </div>
+
+      {/* Bottom toolbar: secrets + cost + user */}
+      <div className="px-3 py-2 border-t border-border-default flex items-center gap-3">
         <button
           type="button"
           onClick={onOpenSecrets}
@@ -1228,46 +1460,18 @@ function HeaderBar({
         >
           <KeyRound className="h-3.5 w-3.5" />
         </button>
-      </div>
-
-      {/* Center: selected agent indicator */}
-      <div className="flex-1 flex items-center justify-center">
-        {selectedAgent ? (
-          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-surface-raised/50 text-xs">
-            <span
-              className={cn(
-                "h-1.5 w-1.5 rounded-full shrink-0",
-                (STATUS_CONFIG[selectedAgent.status] ?? STATUS_CONFIG.stopped).dot,
-                selectedAgent.status === "running" && "animate-breathe",
-                (STATUS_CONFIG[selectedAgent.status] ?? STATUS_CONFIG.stopped).glow,
-              )}
-            />
-            <span className="font-medium text-default">{selectedAgent.name}</span>
-            <span className="text-muted">&middot;</span>
-            <span className="text-muted font-mono">{selectedAgent.model}</span>
-            <span
-              className={cn(
-                "text-[10px] capitalize",
-                STATUS_CONFIG[selectedAgent.status]?.text ?? "text-muted",
-              )}
-            >
-              {selectedAgent.status}
-            </span>
-          </div>
-        ) : (
-          <span className="text-xs text-muted">
-            All agents ({agents.length})
-          </span>
-        )}
-      </div>
-
-      {/* Right: total cost */}
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-muted font-mono">
+        <span className="text-xs text-muted font-mono tabular-nums">
           {formatCost(totalCost)}
         </span>
+        <span className="flex-1" />
+        <div
+          className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
+          title="vahid"
+        >
+          V
+        </div>
       </div>
-    </div>
+    </aside>
   )
 }
 
@@ -1380,114 +1584,6 @@ function TeamFeed() {
   )
 }
 
-/* ================================================================== */
-/*  ICON RAIL — 48px vertical strip replacing the old roster panel     */
-/* ================================================================== */
-
-function IconRail({
-  agents,
-  selectedAgentId,
-  onSelectAgent,
-  onOpenSecrets,
-}: {
-  agents: FakeAgent[]
-  selectedAgentId: string | null
-  onSelectAgent: (id: string) => void
-  onOpenSecrets: () => void
-}) {
-  const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
-    for (const a of agents) counts[a.status] = (counts[a.status] ?? 0) + 1
-    return counts
-  }, [agents])
-
-  return (
-    <div className="w-12 h-full bg-surface-sunken border-r-[0.5px] border-border-default flex flex-col shrink-0">
-      {/* Top: project accent dot */}
-      <div className="pt-3 pb-2 flex justify-center">
-        <span className="h-2 w-2 rounded-full bg-accent" />
-      </div>
-
-      {/* Agent avatars */}
-      <div className="flex-1 flex flex-col items-center gap-1.5 py-2 overflow-y-auto">
-        {agents.map((agent) => {
-          const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
-          const isSelected = selectedAgentId === agent.id
-          const isRunning = agent.status === "running"
-          const isStopped = agent.status === "stopped"
-
-          return (
-            <button
-              key={agent.id}
-              type="button"
-              onClick={() => onSelectAgent(agent.id)}
-              className={cn(
-                "relative group",
-                isStopped && "opacity-55",
-              )}
-              title={agent.name}
-            >
-              <AgentAvatar name={agent.name} size="md" stopped={isStopped} />
-              <span
-                className={cn(
-                  "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface-sunken",
-                  config.dot,
-                  isRunning && "animate-breathe text-success",
-                )}
-              />
-              {isSelected && (
-                <span className="absolute inset-0 rounded-md ring-2 ring-accent/50" />
-              )}
-            </button>
-          )
-        })}
-      </div>
-
-      {/* Fleet health */}
-      <div className="py-2 flex flex-col items-center gap-1 border-t border-border-subtle">
-        {PILL_CONFIG.map(
-          (pill) =>
-            (statusCounts[pill.key] ?? 0) > 0 && (
-              <span
-                key={pill.key}
-                className={cn(
-                  "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
-                  pill.text,
-                )}
-              >
-                <span
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full shrink-0",
-                    pill.dot,
-                    pill.animate && "animate-breathe text-success",
-                  )}
-                />
-                {statusCounts[pill.key]}
-              </span>
-            ),
-        )}
-      </div>
-
-      {/* Bottom: secrets + user avatar */}
-      <div className="py-2 flex flex-col items-center gap-2 border-t border-border-default">
-        <button
-          type="button"
-          onClick={onOpenSecrets}
-          className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
-          title="Project secrets"
-        >
-          <KeyRound className="h-3.5 w-3.5" />
-        </button>
-        <div
-          className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
-          title="vahid"
-        >
-          V
-        </div>
-      </div>
-    </div>
-  )
-}
 
 /* ================================================================== */
 /*  AGENT CARDS + VNC PANEL (unified)                                  */
@@ -1660,53 +1756,56 @@ function AgentSettingsPanel({ agent }: { agent: FakeAgent }) {
   )
 }
 
+type CardState = "collapsed" | "preview" | "expanded"
+
 /**
- * Agent card with two states:
+ * Agent card — three states:
  *
  * COLLAPSED — compact single row:
- *   avatar | name | status dot | live action one-liner | cost · time
- *   SOURCE: Agent model fields + latest tool_use content block (liveAction)
+ *   avatar | name | status dot | live action | cost · time | chevron
  *
- * EXPANDED — full card with VNC + detail feed:
- *   Top: agent info grid (left) + VNC thumbnail (right)
- *   Bottom: scrollable detail feed of verbose output
- *   SOURCE: TimelineEntry.content (full content blocks)
+ * PREVIEW — VNC glance view (no tabs, no detail feed):
+ *   collapsed header + VNC + stats row + live status bar
  *
- * Click toggles between states (onSelect handler does the toggle).
+ * EXPANDED — full detail:
+ *   preview + Activity/Settings tabs + detail feed + mini composer
  */
 function AgentCardRow({
   agent,
-  isSelected,
-  isPreview = false,
+  cardState,
   onSelect,
-  compact = false,
 }: {
   agent: FakeAgent
-  isSelected: boolean
-  isPreview?: boolean
+  cardState: CardState
   onSelect: () => void
-  compact?: boolean
 }) {
   const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
   const isRunning = agent.status === "running"
   const isError = agent.status === "error"
   const isStopped = agent.status === "stopped"
+  const isOpen = cardState !== "collapsed"
+  const isFullDetail = cardState === "expanded"
   const [detailTab, setDetailTab] = useState<"activity" | "settings">("activity")
 
-  /* ---- COLLAPSED: compact single-row card ---- */
-  if (!isSelected && !isPreview) {
-    return (
+  return (
+    <div
+      className={cn(
+        "rounded-lg border transition-all duration-(--duration-normal)",
+        isOpen
+          ? cn("border-accent/40 bg-surface-raised/80 shadow-sm", isError && "border-danger/40")
+          : cn(
+              "border-border-subtle bg-surface hover:bg-surface-raised/40 hover:border-border-default",
+              isError && "border-danger/30 hover:border-danger/40",
+              isStopped && "opacity-60",
+            ),
+      )}
+    >
+      {/* Collapsed row — always visible, click to cycle state */}
       <button
         type="button"
         onClick={onSelect}
-        className={cn(
-          "w-full text-left rounded-lg border px-2.5 py-2 transition-all duration-(--duration-normal)",
-          "border-border-subtle bg-surface hover:bg-surface-raised/40 hover:border-border-default",
-          isError && "border-danger/30 hover:border-danger/40",
-          isStopped && "opacity-60",
-        )}
+        className="w-full text-left px-2.5 py-2"
       >
-        {/* Row 1: avatar + name + status dot + live action + cost/time */}
         <div className="flex items-center gap-2 min-w-0">
           <AgentAvatar name={agent.name} size="sm" stopped={isStopped} />
           <span
@@ -1725,8 +1824,7 @@ function AgentCardRow({
             )}
           />
 
-          {/* Live action one-liner — the continuously updating current action
-              SOURCE: latest tool_use content block name + input summary */}
+          {/* Live action one-liner */}
           {agent.liveAction ? (
             <span className="text-[10px] text-muted font-mono truncate flex-1 min-w-0">
               {agent.liveAction}
@@ -1737,134 +1835,82 @@ function AgentCardRow({
             </span>
           )}
 
-          {/* Right: cost · time */}
+          {/* Right: cost · time + chevron */}
           <span className="text-[9px] text-muted/60 font-mono tabular-nums shrink-0">
             {formatCost(agent.cost)} · {agent.duration}
           </span>
+          <ChevronRight
+            size={14}
+            className={cn(
+              "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+              cardState === "preview" && "rotate-45",
+              cardState === "expanded" && "rotate-90",
+            )}
+          />
         </div>
       </button>
-    )
-  }
 
-  /* ---- Shared header for preview + expanded ---- */
-  const cardHeader = (
-    <button
-      type="button"
-      onClick={onSelect}
-      className="w-full text-left"
-    >
-      {/* Row 1: avatar + name + task + chevron + status dot */}
-      <div className="flex items-center gap-2 px-3 pt-3 pb-2">
-        <AgentAvatar name={agent.name} stopped={isStopped} />
-        <span className="text-[13px] font-medium truncate text-default">
-          {agent.name}
-        </span>
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <Terminal className="h-3 w-3 text-muted/60 shrink-0" />
-          <span className="text-[11px] text-secondary leading-tight truncate">
-            {agent.task}
-          </span>
+      {/* Preview + expanded content — animated reveal */}
+      <Collapsible open={isOpen}>
+        {/* VNC full width */}
+        <div className="px-3 pb-2">
+          <VncThumbnail agent={agent} />
         </div>
-        <ChevronRight
-          size={14}
-          className={cn(
-            "shrink-0 text-muted transition-transform",
-            isSelected && "rotate-90",
-          )}
-        />
-        <span
-          className={cn(
-            "h-2 w-2 rounded-full shrink-0",
-            config.dot,
-            isRunning && "animate-breathe text-success",
-          )}
-        />
-      </div>
 
-      {/* Row 2: VNC full width */}
-      <div className="px-3 pb-2">
-        <VncThumbnail agent={agent} />
-      </div>
+        {/* Stats row */}
+        <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap px-3 pb-2">
+          <span className="inline-flex items-center gap-0.5">
+            <DollarSign className="h-2.5 w-2.5" />
+            {formatCost(agent.cost)}
+          </span>
+          <span className="inline-flex items-center gap-0.5">
+            <Clock className="h-2.5 w-2.5" />
+            {agent.duration}
+          </span>
+          <span className="text-muted/50">&middot;</span>
+          <span>{agent.model}</span>
+          <span className="text-muted/50">&middot;</span>
+          <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
+        </div>
 
-      {/* Row 3: Stats row */}
-      <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap px-3 pb-2">
-        <span className="inline-flex items-center gap-0.5">
-          <DollarSign className="h-2.5 w-2.5" />
-          {formatCost(agent.cost)}
-        </span>
-        <span className="inline-flex items-center gap-0.5">
-          <Clock className="h-2.5 w-2.5" />
-          {agent.duration}
-        </span>
-        <span className="text-muted/50">&middot;</span>
-        <span>{agent.model}</span>
-        <span className="text-muted/50">&middot;</span>
-        <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
-      </div>
-    </button>
-  )
+        {/* Live status bar */}
+        {isRunning && <LiveStatusBar agent={agent} />}
+      </Collapsible>
 
-  /* ---- PREVIEW: header + VNC only, no tabs/feed ---- */
-  if (isPreview && !isSelected) {
-    return (
-      <div
-        className={cn(
-          "rounded-lg border transition-all duration-(--duration-normal)",
-          "border-border-default bg-surface-raised/50",
-          isError && "border-danger/30",
-          isStopped && "opacity-60",
+      {/* Full detail — second collapsible for tabs + feed */}
+      <Collapsible open={isFullDetail}>
+        {/* Inline tab bar — Activity | Settings */}
+        <div className="flex items-center gap-1 px-3 py-1 border-t border-border-subtle bg-surface-sunken/20">
+          <button
+            type="button"
+            onClick={() => setDetailTab("activity")}
+            className={cn(
+              "px-2 py-1 rounded text-[11px] font-medium transition-colors",
+              detailTab === "activity" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
+            )}
+          >
+            Activity
+          </button>
+          <button
+            type="button"
+            onClick={() => setDetailTab("settings")}
+            className={cn(
+              "px-2 py-1 rounded text-[11px] font-medium transition-colors",
+              detailTab === "settings" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
+            )}
+          >
+            <Settings className="h-3 w-3 inline mr-1" />
+            Settings
+          </button>
+        </div>
+
+        {/* Tab content */}
+        {detailTab === "activity" ? (
+          <AgentDetailFeed agent={agent} />
+        ) : (
+          <AgentSettingsPanel agent={agent} />
         )}
-      >
-        {cardHeader}
-      </div>
-    )
-  }
-
-  /* ---- EXPANDED: full card with tabs + detail feed ---- */
-  return (
-    <div
-      className={cn(
-        "rounded-lg border transition-all duration-(--duration-normal)",
-        "border-accent/40 bg-surface-raised/80 shadow-sm",
-        isError && "border-danger/40",
-      )}
-    >
-      {cardHeader}
-
-      {/* Live status bar — card-level, visible regardless of tab */}
-      {isRunning && <LiveStatusBar agent={agent} />}
-
-      {/* Inline tab bar — Activity | Settings */}
-      <div className="flex items-center gap-1 px-3 py-1 border-t border-border-subtle bg-surface-sunken/20">
-        <button
-          type="button"
-          onClick={() => setDetailTab("activity")}
-          className={cn(
-            "px-2 py-1 rounded text-[11px] font-medium transition-colors",
-            detailTab === "activity" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
-          )}
-        >
-          Activity
-        </button>
-        <button
-          type="button"
-          onClick={() => setDetailTab("settings")}
-          className={cn(
-            "px-2 py-1 rounded text-[11px] font-medium transition-colors",
-            detailTab === "settings" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
-          )}
-        >
-          <Settings className="h-3 w-3 inline mr-1" />
-          Settings
-        </button>
-      </div>
-
-      {/* Tab content */}
-      {detailTab === "activity" ? (
-        <AgentDetailFeed agent={agent} />
-      ) : (
-        <AgentSettingsPanel agent={agent} />
-      )}
+      </Collapsible>
     </div>
   )
 }
@@ -2005,16 +2051,12 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
 
 function AgentCardsPanel({
   agents,
-  selectedAgentId,
+  cardStates,
   onSelectAgent,
-  compact = false,
-  allExpanded = false,
 }: {
   agents: FakeAgent[]
-  selectedAgentId: string | null
+  cardStates: Record<string, CardState>
   onSelectAgent: (id: string) => void
-  compact?: boolean
-  allExpanded?: boolean
 }) {
   return (
     <ScrollArea className="h-full overflow-y-auto">
@@ -2023,10 +2065,8 @@ function AgentCardsPanel({
           <AgentCardRow
             key={agent.id}
             agent={agent}
-            isSelected={selectedAgentId === agent.id}
-            isPreview={allExpanded && selectedAgentId !== agent.id}
+            cardState={cardStates[agent.id] ?? "collapsed"}
             onSelect={() => onSelectAgent(agent.id)}
-            compact={compact}
           />
         ))}
       </div>
@@ -2177,62 +2217,72 @@ function ResizeHandle({
 
 export default function PrototypePage() {
   const bp = useBreakpoint()
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>("1")
+  const [cardStates, setCardStates] = useState<Record<string, CardState>>({ "1": "preview" })
   const [mainTab, setMainTab] = useState<"chat" | "agents">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
-  const [rightPanelWidth, setRightPanelWidth] = useState<number | null>(null)
-  const [allExpanded, setAllExpanded] = useState(false)
+  const [agentPanelOpen, setAgentPanelOpen] = useState(true)
+  const [leftPanelWidth, setLeftPanelWidth] = useState<number | null>(null)
 
-  // Reset custom width when breakpoint changes
+  // Reset custom width + auto-collapse on breakpoint change
   useEffect(() => {
-    setRightPanelWidth(null)
+    setLeftPanelWidth(null)
+    if (bp === "S") setAgentPanelOpen(false)
+    else if (bp !== "mobile") setAgentPanelOpen(true)
   }, [bp])
 
-  const selectedAgent = useMemo(
-    () => AGENTS.find((a) => a.id === selectedAgentId) ?? null,
-    [selectedAgentId],
-  )
+  const CARD_CYCLE: Record<CardState, CardState> = { collapsed: "preview", preview: "expanded", expanded: "collapsed" }
 
   const handleSelectAgentCard = useCallback((id: string) => {
-    setSelectedAgentId((prev) => (prev === id ? null : id))
+    setCardStates((prev) => {
+      const current = prev[id] ?? "collapsed"
+      const next = CARD_CYCLE[current]
+      return { ...prev, [id]: next }
+    })
+  }, [])
+
+  const handleToggleExpandAll = useCallback(() => {
+    setCardStates((prev) => {
+      const states = AGENTS.map((a) => prev[a.id] ?? "collapsed")
+      const allExpanded = states.every((s) => s === "expanded")
+      const allPreview = states.every((s) => s === "preview")
+      const allCollapsed = states.every((s) => s === "collapsed")
+
+      let target: CardState
+      if (allCollapsed) target = "preview"
+      else if (allPreview) target = "expanded"
+      else if (allExpanded) target = "collapsed"
+      else target = "preview" // mixed → normalize to preview
+
+      const next: Record<string, CardState> = {}
+      for (const a of AGENTS) next[a.id] = target
+      return next
+    })
   }, [])
 
   // Determine what's visible at each breakpoint
-  const showIconRail = bp !== "mobile"
-  const showRightPanel = bp === "XL" || bp === "L" || bp === "M"
+  const showLeftPanel = bp !== "mobile"
   const showTopTabs = bp === "S" || bp === "mobile"
 
-  // Right panel width: custom if user has resized, else breakpoint default
-  const defaultRightWidth = bp === "M" ? 340 : 480
-  const effectiveRightWidth = rightPanelWidth ?? defaultRightWidth
-  // Compact mode when panel is narrow enough that side-by-side doesn't work
-  const compactCards = effectiveRightWidth < 400
+  // Left panel width: custom if user has resized, else breakpoint default
+  const defaultLeftWidth = bp === "S" ? 340 : bp === "M" ? 340 : 480
+  const effectiveLeftWidth = leftPanelWidth ?? defaultLeftWidth
 
-  const handleRightPanelResize = useCallback((delta: number) => {
-    setRightPanelWidth((prev) => {
-      const current = prev ?? defaultRightWidth
-      // Clamp between 280 and 720
+  const handleLeftPanelResize = useCallback((delta: number) => {
+    setLeftPanelWidth((prev) => {
+      const current = prev ?? defaultLeftWidth
       return Math.max(280, Math.min(720, current + delta))
     })
-  }, [defaultRightWidth])
+  }, [defaultLeftWidth])
 
-  // Top tabs (small screens — no separate Screen tab since VNC is inline with agents)
+  // Top tabs (small screens)
   const topTabs = [
     { id: "chat", label: "Chat", icon: <MessageSquare className="h-3.5 w-3.5" /> },
     { id: "agents", label: "Agents", icon: <Users className="h-3.5 w-3.5" /> },
   ]
 
   return (
-    <div className="h-screen flex flex-col bg-surface overflow-hidden">
-      {/* Header bar */}
-      <header>
-        <h1 className="sr-only">Agentobox Dashboard</h1>
-        <HeaderBar
-          onOpenSecrets={() => setSecretsOpen(true)}
-          selectedAgent={selectedAgent}
-          agents={AGENTS}
-        />
-      </header>
+    <div className="h-screen flex bg-surface overflow-hidden">
+      <h1 className="sr-only">Agentobox Dashboard</h1>
 
       {/* Secrets modal */}
       <SecretsModal
@@ -2241,70 +2291,38 @@ export default function PrototypePage() {
         agents={AGENTS}
       />
 
-      {/* Top tabs (S + mobile) */}
-      {showTopTabs && (
-        <TabBar
-          tabs={topTabs}
-          activeTab={mainTab}
-          onTabChange={(id) => setMainTab(id as "chat" | "agents")}
+      {/* Left panel: collapsed icon rail or open agent cards */}
+      {showLeftPanel && (
+        <AgentLeftPanel
+          agents={AGENTS}
+          cardStates={cardStates}
+          onSelectAgent={handleSelectAgentCard}
+          onToggleExpandAll={handleToggleExpandAll}
+          onOpenSecrets={() => setSecretsOpen(true)}
+          isOpen={agentPanelOpen}
+          onToggleOpen={() => setAgentPanelOpen((p) => !p)}
+          width={effectiveLeftWidth}
+          onResize={handleLeftPanelResize}
+          onResetWidth={() => setLeftPanelWidth(null)}
         />
       )}
 
-      {/* Main layout */}
-      <div className="flex-1 flex min-h-0 overflow-hidden">
-        {/* Icon rail */}
-        {showIconRail && (
-          <aside>
-            <IconRail
-              agents={AGENTS}
-              selectedAgentId={selectedAgentId}
-              onSelectAgent={handleSelectAgentCard}
-              onOpenSecrets={() => setSecretsOpen(true)}
-            />
-          </aside>
+      {/* Right side: tabs (on small) + team feed */}
+      <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
+        {/* Top tabs (S + mobile) */}
+        {showTopTabs && (
+          <TabBar
+            tabs={topTabs}
+            activeTab={mainTab}
+            onTabChange={(id) => setMainTab(id as "chat" | "agents")}
+          />
         )}
 
-        {/* Center: team feed (summaries only — no verbose agent output) */}
+        {/* Center: team feed */}
         {(!showTopTabs || mainTab === "chat") && (
-          <main className="flex-1 min-w-0 flex flex-col">
+          <main className="flex-1 min-w-0 flex flex-col min-h-0">
             <TeamFeed />
           </main>
-        )}
-
-        {/* Right panel: unified agent cards with inline VNC */}
-        {showRightPanel && (
-          <div
-            className="relative border-l border-border-default bg-surface flex flex-col shrink-0"
-            style={{
-              width: effectiveRightWidth,
-              minWidth: effectiveRightWidth,
-            }}
-          >
-            <ResizeHandle onResize={handleRightPanelResize} onReset={() => setRightPanelWidth(null)} side="left" />
-            <PanelHeader>
-              <div className="flex items-center gap-2 flex-1">
-                <Users className="h-3.5 w-3.5 text-muted" />
-                <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">
-                  Agent Activity
-                </span>
-              </div>
-              <button
-                type="button"
-                onClick={() => { setAllExpanded(prev => !prev); if (allExpanded) setSelectedAgentId(null); }}
-                className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
-                title={allExpanded ? "Collapse all" : "Expand all"}
-              >
-                {allExpanded ? <ChevronsDownUp className="h-3.5 w-3.5" /> : <ChevronsUpDown className="h-3.5 w-3.5" />}
-              </button>
-            </PanelHeader>
-            <AgentCardsPanel
-              agents={AGENTS}
-              selectedAgentId={selectedAgentId}
-              onSelectAgent={handleSelectAgentCard}
-              compact={compactCards}
-              allExpanded={allExpanded}
-            />
-          </div>
         )}
 
         {/* Top-tab content: agents (S + mobile) */}
@@ -2312,9 +2330,8 @@ export default function PrototypePage() {
           <div className="flex-1 min-w-0 bg-surface">
             <AgentCardsPanel
               agents={AGENTS}
-              selectedAgentId={selectedAgentId}
+              cardStates={cardStates}
               onSelectAgent={handleSelectAgentCard}
-              allExpanded={allExpanded}
             />
           </div>
         )}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -535,8 +535,7 @@ const ATTENTION_CONFIG: Record<Exclude<AttentionLevel, "none">, { dot: string; l
   permission: { dot: "bg-info",    label: "Permission", text: "text-info",    pulse: true },
 }
 
-// Display order for fleet health pills (highest priority first)
-const LIFECYCLE_PILL_ORDER: LifecycleStatus[] = ["error", "waiting", "running", "deploying", "idle", "stopped"]
+// Priority order (highest first) — used for attention derivation
 const ATTENTION_PILL_ORDER: (Exclude<AttentionLevel, "none">)[] = ["permission", "plan", "review"]
 
 /* ================================================================== */
@@ -1850,102 +1849,6 @@ function SecretsModal({
 }
 
 /* ================================================================== */
-/*  FLEET HEALTH PILLS                                                 */
-/* ================================================================== */
-
-function FleetHealthPills({
-  agents,
-  layout,
-}: {
-  agents: FakeAgent[]
-  layout: "vertical" | "horizontal"
-}) {
-  const lifecycleCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const a of agents) counts[a.lifecycleStatus] = (counts[a.lifecycleStatus] ?? 0) + 1
-    return counts
-  }, [agents])
-
-  const attentionCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const a of agents) {
-      if (a.attentionLevel !== "none") counts[a.attentionLevel] = (counts[a.attentionLevel] ?? 0) + 1
-    }
-    return counts
-  }, [agents])
-
-  const lifecyclePills = LIFECYCLE_PILL_ORDER.filter((k) => (lifecycleCounts[k] ?? 0) > 0)
-  const attentionPills = ATTENTION_PILL_ORDER.filter((k) => (attentionCounts[k] ?? 0) > 0)
-
-  if (lifecyclePills.length === 0 && attentionPills.length === 0) return null
-
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-1",
-        layout === "vertical" ? "flex-col" : "flex-row gap-2",
-      )}
-    >
-      {/* Lifecycle pills */}
-      {lifecyclePills.map((key) => {
-        const cfg = LIFECYCLE_CONFIG[key]
-        return (
-          <span
-            key={key}
-            className={cn(
-              "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
-              cfg.text,
-            )}
-          >
-            <span
-              className={cn(
-                "h-1.5 w-1.5 rounded-full shrink-0",
-                cfg.dot,
-                key === "running" && "animate-breathe text-success",
-              )}
-            />
-            {lifecycleCounts[key]}
-          </span>
-        )
-      })}
-
-      {/* Separator + attention pills */}
-      {attentionPills.length > 0 && (
-        <>
-          {lifecyclePills.length > 0 && (
-            <span className="text-muted/30 text-[9px]">&middot;</span>
-          )}
-          {attentionPills.map((key) => {
-            const cfg = ATTENTION_CONFIG[key]
-            return (
-              <span
-                key={key}
-                className={cn(
-                  "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
-                  cfg.text,
-                )}
-              >
-                <span
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full shrink-0",
-                    cfg.dot,
-                    cfg.pulse && "animate-breathe",
-                  )}
-                />
-                {attentionCounts[key]}
-                {layout === "horizontal" && (
-                  <span className="ml-0.5">{cfg.label.toLowerCase()}</span>
-                )}
-              </span>
-            )
-          })}
-        </>
-      )}
-    </div>
-  )
-}
-
-/* ================================================================== */
 /*  AGENT LEFT PANEL — unified icon rail + agent cards                 */
 /* ================================================================== */
 
@@ -2021,17 +1924,35 @@ function AgentLeftPanel({
         {/* Hover edge hint — subtle accent line on right edge */}
         <div className="absolute top-0 bottom-0 right-0 w-px bg-transparent group-hover/rail:bg-accent/25 transition-colors" />
 
-        {/* Project initial */}
-        <button
-          type="button"
-          onClick={onToggleOpen}
-          className="pt-3 pb-2 flex justify-center hover:bg-surface-raised/30 transition-colors"
-          title="Open panel"
-        >
+        {/* Project icon + secrets + cost */}
+        <div className="pt-3 pb-1 flex flex-col items-center gap-1.5">
           <div className="h-6 w-6 rounded-md bg-accent/15 flex items-center justify-center text-[11px] font-bold text-accent">
             A
           </div>
-        </button>
+          <button
+            type="button"
+            onClick={onOpenSecrets}
+            className="p-1 rounded-md text-muted/50 hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+            title="Project secrets"
+          >
+            <KeyRound className="h-3 w-3" />
+          </button>
+          <span className="text-[8px] text-muted/50 font-mono tabular-nums">
+            {formatCost(totalCost)}
+          </span>
+        </div>
+
+        {/* Expand button */}
+        <div className="flex justify-center pb-1.5 border-b border-border-subtle mb-1">
+          <button
+            type="button"
+            onClick={onToggleOpen}
+            className="p-1 rounded-md text-muted/40 hover:text-accent hover:bg-accent/10 transition-colors"
+            title="Expand panel"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
 
         {/* Agent avatars */}
         <div className="flex-1 flex flex-col items-center gap-1.5 py-2 overflow-y-auto">
@@ -2084,38 +2005,10 @@ function AgentLeftPanel({
           })}
         </div>
 
-        {/* Fleet health */}
-        <div className="py-2 flex flex-col items-center gap-1 border-t border-border-subtle">
-          <FleetHealthPills agents={agents} layout="vertical" />
-        </div>
-
-        {/* Expand button — explicit affordance */}
-        <div className="flex justify-center py-1.5 border-t border-border-subtle">
-          <button
-            type="button"
-            onClick={onToggleOpen}
-            className="p-1 rounded-md text-muted/40 hover:text-accent hover:bg-accent/10 transition-colors"
-            title="Expand panel"
-          >
-            <ChevronRight className="h-3.5 w-3.5" />
-          </button>
-        </div>
-
-        {/* Bottom: secrets + cost + user avatar */}
-        <div className="py-2 flex flex-col items-center gap-2 border-t border-border-default">
-          <button
-            type="button"
-            onClick={onOpenSecrets}
-            className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
-            title="Project secrets"
-          >
-            <KeyRound className="h-3.5 w-3.5" />
-          </button>
-          <span className="text-[9px] text-muted/60 font-mono tabular-nums">
-            {formatCost(totalCost)}
-          </span>
+        {/* Bottom: user avatar */}
+        <div className="py-3 flex flex-col items-center border-t border-border-default">
           <div
-            className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
+            className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent cursor-pointer hover:ring-2 hover:ring-accent/30 transition-shadow"
             title="vahid"
           >
             V
@@ -2133,18 +2026,30 @@ function AgentLeftPanel({
     >
       <ResizeHandle onResize={onResize} onReset={onResetWidth} side="right" />
 
-      {/* Project selector placeholder */}
+      {/* Project selector + secrets + cost */}
       <div className="h-10 px-3 flex items-center border-b border-border-default shrink-0">
         <button
           type="button"
-          className="inline-flex items-center gap-2 px-1 py-1 -ml-1 rounded-md hover:bg-surface-sunken/40 transition-colors flex-1 min-w-0"
+          className="inline-flex items-center gap-2 px-1 py-1 -ml-1 rounded-md hover:bg-surface-sunken/40 transition-colors min-w-0"
         >
           <div className="h-6 w-6 rounded-md bg-accent/15 flex items-center justify-center text-[11px] font-bold text-accent shrink-0">
             A
           </div>
-          <span className="text-sm font-medium text-default">agentobox</span>
+          <span className="text-sm font-medium text-default truncate">agentobox</span>
           <ChevronRight size={12} className="text-muted/40 rotate-90 shrink-0" />
         </button>
+        <span className="flex-1" />
+        <button
+          type="button"
+          onClick={onOpenSecrets}
+          className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors shrink-0"
+          title="Project secrets"
+        >
+          <KeyRound className="h-3.5 w-3.5" />
+        </button>
+        <span className="text-[10px] text-muted/60 font-mono tabular-nums mx-1 shrink-0">
+          {formatCost(totalCost)}
+        </span>
         <button
           type="button"
           onClick={onToggleOpen}
@@ -2369,34 +2274,15 @@ function AgentLeftPanel({
             </div>
           )}
 
-          {/* Fleet health horizontal */}
-          <div className="px-3 py-1.5 border-t border-border-subtle flex items-center gap-2 shrink-0">
-            <FleetHealthPills agents={agents} layout="horizontal" />
-            <span className="text-[9px] text-muted/40 font-mono ml-auto">
-              {agents.length} agents
-            </span>
-          </div>
         </>
       ) : (
         <SkillsPanel allExpanded={skillsAllExpanded} />
       )}
 
-      {/* Bottom toolbar: secrets + cost + user */}
-      <div className="px-3 py-2 border-t border-border-default flex items-center gap-3 shrink-0">
-        <button
-          type="button"
-          onClick={onOpenSecrets}
-          className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
-          title="Project secrets"
-        >
-          <KeyRound className="h-3.5 w-3.5" />
-        </button>
-        <span className="text-xs text-muted font-mono tabular-nums">
-          {formatCost(totalCost)}
-        </span>
-        <span className="flex-1" />
+      {/* Bottom: user avatar */}
+      <div className="px-3 py-2 border-t border-border-default flex items-center shrink-0">
         <div
-          className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
+          className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent cursor-pointer hover:ring-2 hover:ring-accent/30 transition-shadow"
           title="vahid"
         >
           V
@@ -2556,41 +2442,22 @@ function AttentionBar({
             ? `${item.agent} wants to run: ${item.command}`
             : `${item.agent} proposed: ${item.title}`}
         </span>
-        {item.type === "permission" ? (
-          <div className="flex items-center gap-1 shrink-0">
-            <button
-              type="button"
-              onClick={() => onResolvePermission(feedIndex, "allowed")}
-              className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-            >
-              Allow
-            </button>
-            <button
-              type="button"
-              onClick={() => onResolvePermission(feedIndex, "denied")}
-              className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-            >
-              Deny
-            </button>
-          </div>
-        ) : (
-          <div className="flex items-center gap-1 shrink-0">
-            <button
-              type="button"
-              onClick={() => onResolvePlan(feedIndex, "approved")}
-              className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-            >
-              Approve
-            </button>
-            <button
-              type="button"
-              onClick={() => onResolvePlan(feedIndex, "rejected")}
-              className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-            >
-              Reject
-            </button>
-          </div>
-        )}
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => item.type === "permission" ? onResolvePermission(feedIndex, "allowed") : onResolvePlan(feedIndex, "approved")}
+            className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+          >
+            Allow
+          </button>
+          <button
+            type="button"
+            onClick={() => item.type === "permission" ? onResolvePermission(feedIndex, "denied") : onResolvePlan(feedIndex, "rejected")}
+            className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+          >
+            Deny
+          </button>
+        </div>
       </div>
     </div>
   )
@@ -3684,6 +3551,7 @@ function AgentCardsPanel({
   agents,
   expandedIds,
   onToggleAgent,
+  onToggleExpandAll,
   feedItems,
   onResolvePermission,
   onResolvePlan,
@@ -3691,26 +3559,162 @@ function AgentCardsPanel({
   agents: FakeAgent[]
   expandedIds: Set<string>
   onToggleAgent: (id: string) => void
+  onToggleExpandAll?: () => void
   feedItems?: TeamFeedItem[]
   onResolvePermission?: (feedIndex: number, verdict: "allowed" | "denied") => void
   onResolvePlan?: (feedIndex: number, verdict: "approved" | "rejected") => void
 }) {
+  const [searchQuery, setSearchQuery] = useState("")
+  const [tagFilter, setTagFilter] = useState<string | null>(null)
+  const [showTagDropdown, setShowTagDropdown] = useState(false)
+  const [selectMode, setSelectMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  const filteredAgents = useMemo(() => {
+    let result = agents
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(a => a.name.toLowerCase().includes(q) || a.tags.some(t => t.includes(q)))
+    }
+    if (tagFilter) {
+      result = result.filter(a => a.tags.includes(tagFilter))
+    }
+    return result
+  }, [agents, searchQuery, tagFilter])
+
+  const handleSelectAgent = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const exitSelectMode = () => {
+    setSelectMode(false)
+    setSelectedIds(new Set())
+  }
+
   return (
-    <ScrollArea className="h-full overflow-y-auto">
-      <div className="p-3 space-y-2">
-        {agents.map((agent) => (
-          <AgentCardRow
-            key={agent.id}
-            agent={agent}
-            isOpen={expandedIds.has(agent.id)}
-            onToggle={() => onToggleAgent(agent.id)}
-            pendingItems={feedItems ? getPendingItemsForAgent(feedItems, agent.name) : []}
-            onResolvePermission={onResolvePermission}
-            onResolvePlan={onResolvePlan}
+    <>
+      {/* Toolbar: search + tags + select + create + expand */}
+      <div className="px-3 py-2 flex items-center gap-2 border-b border-border-subtle shrink-0">
+        <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded-md border border-border-default bg-surface-sunken/40 px-2 py-1">
+          <Search className="h-3 w-3 text-muted/50 shrink-0" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search agents..."
+            className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
           />
-        ))}
+        </div>
+        <div className="relative shrink-0">
+          <button
+            type="button"
+            onClick={() => setShowTagDropdown(!showTagDropdown)}
+            className={cn(
+              "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors",
+              tagFilter
+                ? "border-accent/30 bg-accent/10 text-accent"
+                : "border-border-default text-muted hover:text-secondary hover:bg-surface-raised/40",
+            )}
+          >
+            <Filter className="h-3 w-3" />
+            {tagFilter || "Tags"}
+            <ChevronRight size={10} className="rotate-90 text-muted/40" />
+          </button>
+          {showTagDropdown && (
+            <div className="absolute top-full right-0 mt-1 w-32 rounded-md border border-border-default bg-surface-raised shadow-lg z-(--z-dropdown) overflow-hidden">
+              <button
+                type="button"
+                onClick={() => { setTagFilter(null); setShowTagDropdown(false) }}
+                className={cn(
+                  "w-full text-left px-3 py-1.5 text-[11px] transition-colors",
+                  !tagFilter ? "text-accent bg-accent/10" : "text-secondary hover:bg-surface-sunken/40",
+                )}
+              >
+                All tags
+              </button>
+              {ALL_TAGS.map(tag => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => { setTagFilter(tag); setShowTagDropdown(false) }}
+                  className={cn(
+                    "w-full text-left px-3 py-1.5 text-[11px] font-mono transition-colors",
+                    tagFilter === tag ? "text-accent bg-accent/10" : "text-secondary hover:bg-surface-sunken/40",
+                  )}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => selectMode ? exitSelectMode() : setSelectMode(true)}
+          className={cn(
+            "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors shrink-0",
+            selectMode
+              ? "border-accent/30 bg-accent/10 text-accent"
+              : "border-border-default text-muted hover:text-secondary hover:bg-surface-raised/40",
+          )}
+        >
+          <CheckSquare className="h-3 w-3" />
+          {selectMode ? "Done" : "Select"}
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors shrink-0 text-muted hover:text-secondary hover:bg-surface-raised/50"
+        >
+          <Plus className="h-3 w-3" />
+          Create
+        </button>
+        {onToggleExpandAll && (
+          <button
+            type="button"
+            onClick={onToggleExpandAll}
+            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors shrink-0"
+            title="Cycle card states"
+          >
+            {expandedIds.size > 0 ? (
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
       </div>
-    </ScrollArea>
+
+      {/* Agent cards */}
+      <ScrollArea className="flex-1 overflow-y-auto">
+        <div className="p-3 space-y-2">
+          {filteredAgents.map((agent) => (
+            <AgentCardRow
+              key={agent.id}
+              agent={agent}
+              isOpen={!selectMode && expandedIds.has(agent.id)}
+              onToggle={() => selectMode ? handleSelectAgent(agent.id) : onToggleAgent(agent.id)}
+              selectable={selectMode}
+              selected={selectedIds.has(agent.id)}
+              onSelect={() => handleSelectAgent(agent.id)}
+              pendingItems={feedItems ? getPendingItemsForAgent(feedItems, agent.name) : []}
+              onResolvePermission={onResolvePermission}
+              onResolvePlan={onResolvePlan}
+            />
+          ))}
+          {filteredAgents.length === 0 && (
+            <div className="py-6 text-center">
+              <Users className="h-5 w-5 text-muted/20 mx-auto mb-1" />
+              <p className="text-[11px] text-muted/50">No agents match filters</p>
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </>
   )
 }
 
@@ -3873,14 +3877,12 @@ export default function PrototypePage() {
   const [focusedAgentId, setFocusedAgentId] = useState<string | null>("1")
   const [mainTab, setMainTab] = useState<"chat" | "agents" | "skills">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
-  const [agentPanelOpen, setAgentPanelOpen] = useState(true)
+  const [agentPanelOpen, setAgentPanelOpen] = useState(() => bp !== "S" && bp !== "mobile")
   const [leftPanelWidth, setLeftPanelWidth] = useState<number | null>(null)
 
-  // Reset custom width + auto-collapse on breakpoint change
+  // Reset custom panel width on breakpoint change (keep open/closed state as-is)
   useEffect(() => {
     setLeftPanelWidth(null)
-    if (bp === "S") setAgentPanelOpen(false)
-    else if (bp !== "mobile") setAgentPanelOpen(true)
   }, [bp])
 
   const handleToggleAgent = useCallback((id: string) => {
@@ -3938,8 +3940,8 @@ export default function PrototypePage() {
   const pendingCount = useMemo(() => getAllPendingItems(feedItems).length, [feedItems])
 
   // Determine what's visible at each breakpoint
+  const showTopTabs = bp === "mobile"
   const showLeftPanel = bp !== "mobile"
-  const showTopTabs = bp === "S" || bp === "mobile"
 
   // Left panel width: custom if user has resized, else breakpoint default
   const defaultLeftWidth = bp === "S" ? 340 : bp === "M" ? 340 : 480
@@ -3948,7 +3950,13 @@ export default function PrototypePage() {
   const handleLeftPanelResize = useCallback((delta: number) => {
     setLeftPanelWidth((prev) => {
       const current = prev ?? defaultLeftWidth
-      return Math.max(280, Math.min(720, current + delta))
+      const next = current + delta
+      // Snap to collapsed if dragged below threshold
+      if (next < 360) {
+        setAgentPanelOpen(false)
+        return null // reset to default for when they re-expand
+      }
+      return Math.max(360, Math.min(720, next))
     })
   }, [defaultLeftWidth])
 
@@ -4052,11 +4060,12 @@ export default function PrototypePage() {
 
         {/* Top-tab content: agents (S + mobile) */}
         {showTopTabs && mainTab === "agents" && (
-          <div className="flex-1 min-w-0 bg-surface flex flex-col">
+          <div className="flex-1 min-w-0 bg-surface flex flex-col overflow-hidden">
             <AgentCardsPanel
               agents={agents}
               expandedIds={expandedIds}
               onToggleAgent={handleToggleAgent}
+              onToggleExpandAll={handleToggleExpandAll}
               feedItems={feedItems}
               onResolvePermission={handleResolvePermission}
               onResolvePlan={handleResolvePlan}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1400,6 +1400,7 @@ function AgentLeftPanel({
   const [searchQuery, setSearchQuery] = useState("")
   const [tagFilter, setTagFilter] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [selectMode, setSelectMode] = useState(false)
   const [showTagDropdown, setShowTagDropdown] = useState(false)
   const [skillsAllExpanded, setSkillsAllExpanded] = useState(false)
 
@@ -1423,8 +1424,6 @@ function AgentLeftPanel({
     return result
   }, [agents, searchQuery, tagFilter])
 
-  const selectable = selectedIds.size > 0
-
   const handleSelectAgent = useCallback((id: string) => {
     setSelectedIds(prev => {
       const next = new Set(prev)
@@ -1432,6 +1431,11 @@ function AgentLeftPanel({
       else next.add(id)
       return next
     })
+  }, [])
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false)
+    setSelectedIds(new Set())
   }, [])
 
   /* ---- Collapsed state: 48px icon rail ---- */
@@ -1678,6 +1682,19 @@ function AgentLeftPanel({
                 </div>
               )}
             </div>
+            <button
+              type="button"
+              onClick={() => selectMode ? exitSelectMode() : setSelectMode(true)}
+              className={cn(
+                "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors shrink-0",
+                selectMode
+                  ? "border-accent/30 bg-accent/10 text-accent"
+                  : "border-border-default text-muted hover:text-secondary hover:bg-surface-raised/40",
+              )}
+            >
+              <CheckSquare className="h-3 w-3" />
+              {selectMode ? "Done" : "Select"}
+            </button>
           </div>
 
           {/* Agent cards */}
@@ -1687,9 +1704,9 @@ function AgentLeftPanel({
                 <AgentCardRow
                   key={agent.id}
                   agent={agent}
-                  isOpen={expandedIds.has(agent.id)}
-                  onToggle={() => onToggleAgent(agent.id)}
-                  selectable={selectable}
+                  isOpen={!selectMode && expandedIds.has(agent.id)}
+                  onToggle={() => selectMode ? handleSelectAgent(agent.id) : onToggleAgent(agent.id)}
+                  selectable={selectMode}
                   selected={selectedIds.has(agent.id)}
                   onSelect={() => handleSelectAgent(agent.id)}
                 />
@@ -1703,9 +1720,22 @@ function AgentLeftPanel({
             </div>
           </ScrollArea>
 
-          {/* Bulk action bar — when agents are selected */}
-          {selectedIds.size > 0 && (
+          {/* Bulk action bar — when in select mode */}
+          {selectMode && (
             <div className="px-3 py-1.5 border-t border-border-subtle bg-surface-sunken/30 flex items-center gap-2 shrink-0">
+              <button
+                type="button"
+                onClick={() => {
+                  if (selectedIds.size === filteredAgents.length) {
+                    setSelectedIds(new Set())
+                  } else {
+                    setSelectedIds(new Set(filteredAgents.map(a => a.id)))
+                  }
+                }}
+                className="text-[11px] text-accent hover:text-accent-hover transition-colors shrink-0"
+              >
+                {selectedIds.size === filteredAgents.length ? "Deselect all" : "Select all"}
+              </button>
               <span className="text-[11px] font-medium text-default shrink-0">
                 {selectedIds.size} selected
               </span>
@@ -1718,6 +1748,16 @@ function AgentLeftPanel({
                 {SKILLS.map(s => (
                   <option key={s.id} value={s.id}>{s.name}</option>
                 ))}
+              </select>
+              <select
+                className="bg-surface-sunken/60 border border-border-default rounded-md px-2 py-1 text-[11px] text-secondary outline-none"
+                defaultValue=""
+                onChange={() => {}}
+              >
+                <option value="" disabled>Set model...</option>
+                <option>Opus 4.6</option>
+                <option>Sonnet 4.6</option>
+                <option>Haiku 4.5</option>
               </select>
               <span className="flex-1" />
               <button
@@ -2271,11 +2311,7 @@ function AgentCardRow({
       {/* Header row — always visible, click to toggle */}
       <button
         type="button"
-        onClick={(e) => {
-          if (e.shiftKey && onSelect) {
-            onSelect()
-            return
-          }
+        onClick={() => {
           if (selectable && onSelect) {
             onSelect()
           } else {
@@ -2532,6 +2568,8 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
   const [newName, setNewName] = useState("")
   const [newContent, setNewContent] = useState("")
   const [newTags, setNewTags] = useState<string[]>([])
+  const [selectMode, setSelectMode] = useState(false)
+  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set())
 
   const filtered = useMemo(() => {
     if (!search.trim()) return SKILLS
@@ -2555,6 +2593,26 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
             className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
           />
         </div>
+        <button
+          type="button"
+          onClick={() => {
+            if (selectMode) {
+              setSelectMode(false)
+              setSelectedSkills(new Set())
+            } else {
+              setSelectMode(true)
+            }
+          }}
+          className={cn(
+            "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors shrink-0",
+            selectMode
+              ? "border-accent/30 bg-accent/10 text-accent"
+              : "border-border-default text-muted hover:text-secondary hover:bg-surface-raised/40",
+          )}
+        >
+          <CheckSquare className="h-3 w-3" />
+          {selectMode ? "Done" : "Select"}
+        </button>
         <button
           type="button"
           onClick={() => setShowCreate(!showCreate)}
@@ -2622,27 +2680,55 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
             </div>
           ) : (
             filtered.map((skill) => {
-              const isExpanded = allExpanded || expandedSkills.has(skill.id)
+              const isExpanded = !selectMode && (allExpanded || expandedSkills.has(skill.id))
+              const isSelected = selectedSkills.has(skill.id)
               return (
-                <div key={skill.id} className="rounded-lg border border-border-subtle overflow-hidden">
+                <div key={skill.id} className={cn(
+                  "rounded-lg border overflow-hidden",
+                  selectMode && isSelected ? "border-accent/40" : "border-border-subtle",
+                )}>
                   <button
                     type="button"
-                    onClick={() => setExpandedSkills(prev => {
-                      const next = new Set(prev)
-                      if (next.has(skill.id)) next.delete(skill.id)
-                      else next.add(skill.id)
-                      return next
-                    })}
+                    onClick={() => {
+                      if (selectMode) {
+                        setSelectedSkills(prev => {
+                          const next = new Set(prev)
+                          if (next.has(skill.id)) next.delete(skill.id)
+                          else next.add(skill.id)
+                          return next
+                        })
+                      } else {
+                        setExpandedSkills(prev => {
+                          const next = new Set(prev)
+                          if (next.has(skill.id)) next.delete(skill.id)
+                          else next.add(skill.id)
+                          return next
+                        })
+                      }
+                    }}
                     className="w-full text-left px-2.5 py-2 hover:bg-surface-raised/30 transition-colors"
                   >
                     <div className="flex items-center gap-2 min-w-0">
-                      <ChevronRight
-                        size={12}
-                        className={cn(
-                          "shrink-0 text-muted transition-transform duration-(--duration-normal)",
-                          isExpanded && "rotate-90",
-                        )}
-                      />
+                      {selectMode ? (
+                        <div
+                          className={cn(
+                            "h-3.5 w-3.5 rounded border flex items-center justify-center shrink-0",
+                            isSelected
+                              ? "bg-accent/20 border-accent/50"
+                              : "border-border-default",
+                          )}
+                        >
+                          {isSelected && <Check className="h-2.5 w-2.5 text-accent" strokeWidth={3} />}
+                        </div>
+                      ) : (
+                        <ChevronRight
+                          size={12}
+                          className={cn(
+                            "shrink-0 text-muted transition-transform duration-(--duration-normal)",
+                            isExpanded && "rotate-90",
+                          )}
+                        />
+                      )}
                       <span className="text-xs font-medium text-default flex-1 min-w-0 truncate">
                         {skill.name}
                       </span>
@@ -2681,6 +2767,42 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
           )}
         </div>
       </ScrollArea>
+
+      {/* Bulk action bar for skills */}
+      {selectMode && (
+        <div className="px-3 py-1.5 border-t border-border-subtle bg-surface-sunken/30 flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={() => {
+              if (selectedSkills.size === filtered.length) {
+                setSelectedSkills(new Set())
+              } else {
+                setSelectedSkills(new Set(filtered.map(s => s.id)))
+              }
+            }}
+            className="text-[11px] text-accent hover:text-accent-hover transition-colors shrink-0"
+          >
+            {selectedSkills.size === filtered.length ? "Deselect all" : "Select all"}
+          </button>
+          <span className="text-[11px] text-muted shrink-0">
+            {selectedSkills.size} selected
+          </span>
+          <span className="flex-1" />
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors",
+              selectedSkills.size > 0
+                ? "text-danger hover:bg-danger-subtle/40"
+                : "text-muted cursor-not-allowed",
+            )}
+            disabled={selectedSkills.size === 0}
+          >
+            <Trash2 className="h-3 w-3" />
+            Delete
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -2448,9 +2448,9 @@ function RecipientSearchBox({
   }, [suggestions, onSuggestionsChange])
 
   return (
-    <div className="min-w-0 flex-1">
+    <div className="min-w-0">
       {/* Dark search input */}
-      <div className="relative flex items-center min-w-0 rounded-md bg-surface-sunken/50 px-2 py-1">
+      <div className="relative flex items-center min-w-0 rounded-md border border-border-subtle/50 bg-surface-sunken/30 px-2 py-0.5 w-36">
         <span
           ref={measureRef}
           className="invisible absolute whitespace-pre text-[11px] font-mono"

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import {
-  PanelLeftClose,
-  PanelLeftOpen,
   ArrowUp,
   Users,
   MessageSquare,
@@ -23,6 +21,9 @@ import {
   Trash2,
   AlertTriangle,
   RefreshCw,
+  ChevronsUpDown,
+  ChevronsDownUp,
+  Settings,
 } from "lucide-react"
 import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -48,6 +49,10 @@ type FakeAgent = {
   /** Live one-liner: last tool call or action, continuously updated.
    *  SOURCE: latest tool_use content block name + summary from StreamEvent */
   liveAction?: string
+  instructions: string
+  mcpServers: string[]
+  runtime: "docker" | "modal"
+  workspacePath: string
 }
 
 const AGENTS: FakeAgent[] = [
@@ -63,6 +68,10 @@ const AGENTS: FakeAgent[] = [
     lastOutput: "Applied fix to validateToken()...",
     phase: "Editing",
     liveAction: "Edit src/auth.ts (+3 -1)",
+    instructions: "Django 6.0 backend: models, services, auth, GraphQL schema. Run tests before committing.",
+    mcpServers: ["computer-use"],
+    runtime: "docker",
+    workspacePath: "/workspace/agentobox",
   },
   {
     id: "2",
@@ -76,6 +85,10 @@ const AGENTS: FakeAgent[] = [
     lastOutput: "Scanning tailwind classes in Button...",
     phase: "Reading",
     liveAction: "Read src/components/Button.tsx",
+    instructions: "Next.js dashboard: components, stores, GraphQL client, Tailwind CSS. Follow design tokens.",
+    mcpServers: ["playwright", "computer-use"],
+    runtime: "docker",
+    workspacePath: "/workspace/agentobox",
   },
   {
     id: "3",
@@ -88,6 +101,10 @@ const AGENTS: FakeAgent[] = [
     turns: 3,
     lastOutput: "FAIL src/auth.test.ts\nExpected 200, received 401",
     liveAction: "Bash npm test -- --filter auth",
+    instructions: "Run test suites, deploy test agents, Playwright E2E. Report failures with reproduction steps.",
+    mcpServers: ["playwright"],
+    runtime: "docker",
+    workspacePath: "/workspace/agentobox",
   },
   {
     id: "4",
@@ -99,6 +116,10 @@ const AGENTS: FakeAgent[] = [
     model: "Haiku 4.5",
     turns: 1,
     lastOutput: "Standing by...",
+    instructions: "Infrastructure: Docker, CI/CD, Modal config, monitoring. No destructive ops without approval.",
+    mcpServers: ["computer-use"],
+    runtime: "modal",
+    workspacePath: "/workspace/agentobox",
   },
   {
     id: "5",
@@ -111,6 +132,10 @@ const AGENTS: FakeAgent[] = [
     turns: 2,
     lastOutput: "Updated API reference section",
     liveAction: "Edit docs/api-reference.md (+12 -3)",
+    instructions: "Documentation: API reference, architecture docs, migration guides. Keep examples current.",
+    mcpServers: [],
+    runtime: "docker",
+    workspacePath: "/workspace/agentobox",
   },
   {
     id: "6",
@@ -122,6 +147,10 @@ const AGENTS: FakeAgent[] = [
     model: "Haiku 4.5",
     turns: 0,
     lastOutput: "Initializing workspace...",
+    instructions: "Provisioning: container orchestration, volume management, network config.",
+    mcpServers: [],
+    runtime: "modal",
+    workspacePath: "/workspace/agentobox",
   },
 ]
 
@@ -1153,33 +1182,20 @@ function SecretsModal({
 /* ================================================================== */
 
 function HeaderBar({
-  onToggleSidebar,
   onOpenSecrets,
   selectedAgent,
   agents,
-  showSidebarToggle = true,
 }: {
-  onToggleSidebar: () => void
   onOpenSecrets: () => void
   selectedAgent: FakeAgent | null
   agents: FakeAgent[]
-  showSidebarToggle?: boolean
 }) {
   const totalCost = agents.reduce((sum, a) => sum + a.cost, 0)
 
   return (
     <div className="h-12 border-b border-border-default bg-surface-sunken px-4 flex items-center gap-4 shrink-0">
-      {/* Left: sidebar toggle + project name + secrets */}
+      {/* Left: project name + secrets */}
       <div className="flex items-center gap-2">
-        {showSidebarToggle && (
-          <button
-            type="button"
-            onClick={onToggleSidebar}
-            className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
-          >
-            <PanelLeftClose className="h-4 w-4" />
-          </button>
-        )}
         <span className="text-sm font-medium text-default">agentobox</span>
         <button
           type="button"
@@ -1342,21 +1358,19 @@ function TeamFeed() {
 }
 
 /* ================================================================== */
-/*  ROSTER PANEL                                                       */
+/*  ICON RAIL — 48px vertical strip replacing the old roster panel     */
 /* ================================================================== */
 
-function RosterPanel({
-  collapsed,
-  onToggle,
+function IconRail({
   agents,
   selectedAgentId,
   onSelectAgent,
+  onOpenSecrets,
 }: {
-  collapsed: boolean
-  onToggle: () => void
   agents: FakeAgent[]
   selectedAgentId: string | null
-  onSelectAgent: (id: string | null) => void
+  onSelectAgent: (id: string) => void
+  onOpenSecrets: () => void
 }) {
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
@@ -1365,209 +1379,87 @@ function RosterPanel({
   }, [agents])
 
   return (
-    <div
-      className="h-full bg-surface-sunken border-r-[0.5px] border-border-default flex flex-col overflow-hidden shrink-0"
-      style={{
-        width: collapsed ? 60 : 260,
-        minWidth: collapsed ? 60 : 260,
-        transition: "width 200ms ease, min-width 200ms ease",
-      }}
-    >
-      <div className="flex-1 flex flex-col bg-surface min-h-0">
-        {/* Header — h-8 to align with session info bar + right panel tab bar */}
-        <div className={cn(
-          "h-8 px-3 flex items-center border-b border-border-default shrink-0",
-          collapsed && "justify-center px-1.5",
-        )}>
-          {!collapsed && (
-            <div className="flex items-center gap-1.5 flex-1 min-w-0">
-              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">
-                Agents
-              </span>
-              <div className="flex items-center gap-1.5 ml-1">
-                {PILL_CONFIG.map(
-                  (pill) =>
-                    (statusCounts[pill.key] ?? 0) > 0 && (
-                      <span
-                        key={pill.key}
-                        className={cn(
-                          "inline-flex items-center gap-0.5 font-mono text-[10px] tabular-nums",
-                          pill.text,
-                        )}
-                      >
-                        <span
-                          className={cn(
-                            "h-1.5 w-1.5 rounded-full shrink-0",
-                            pill.dot,
-                            pill.animate && "animate-breathe text-success",
-                          )}
-                        />
-                        {statusCounts[pill.key]}
-                      </span>
-                    ),
-                )}
-              </div>
-            </div>
-          )}
-          <button
-            type="button"
-            onClick={onToggle}
-            className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors shrink-0"
-            aria-label={collapsed ? "Expand roster" : "Collapse roster"}
-          >
-            {collapsed ? (
-              <PanelLeftOpen className="h-3.5 w-3.5" />
-            ) : (
-              <PanelLeftClose className="h-3.5 w-3.5" />
-            )}
-          </button>
-        </div>
+    <div className="w-12 h-full bg-surface-sunken border-r-[0.5px] border-border-default flex flex-col shrink-0">
+      {/* Top: project accent dot */}
+      <div className="pt-3 pb-2 flex justify-center">
+        <span className="h-2 w-2 rounded-full bg-accent" />
+      </div>
 
-        {/* Agent list */}
-        <ScrollArea className="flex-1 overflow-y-auto">
-          <div className="flex flex-col pt-1.5 pb-2">
-            {/* All agents button */}
-            {!collapsed && (
-              <button
-                type="button"
-                onClick={() => onSelectAgent(null)}
+      {/* Agent avatars */}
+      <div className="flex-1 flex flex-col items-center gap-1.5 py-2 overflow-y-auto">
+        {agents.map((agent) => {
+          const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
+          const isSelected = selectedAgentId === agent.id
+          const isRunning = agent.status === "running"
+          const isStopped = agent.status === "stopped"
+
+          return (
+            <button
+              key={agent.id}
+              type="button"
+              onClick={() => onSelectAgent(agent.id)}
+              className={cn(
+                "relative group",
+                isStopped && "opacity-55",
+              )}
+              title={agent.name}
+            >
+              <AgentAvatar name={agent.name} size="md" stopped={isStopped} />
+              <span
                 className={cn(
-                  "mx-1.5 rounded-lg transition-all duration-(--duration-normal) text-left px-3 py-2",
-                  "border-l-2 border-transparent",
-                  selectedAgentId === null
-                    ? "bg-surface-raised/80 border-l-accent"
-                    : "hover:bg-surface-raised/30",
+                  "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface-sunken",
+                  config.dot,
+                  isRunning && "animate-breathe text-success",
+                )}
+              />
+              {isSelected && (
+                <span className="absolute inset-0 rounded-md ring-2 ring-accent/50" />
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Fleet health */}
+      <div className="py-2 flex flex-col items-center gap-1 border-t border-border-subtle">
+        {PILL_CONFIG.map(
+          (pill) =>
+            (statusCounts[pill.key] ?? 0) > 0 && (
+              <span
+                key={pill.key}
+                className={cn(
+                  "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
+                  pill.text,
                 )}
               >
-                <div className="flex items-center gap-2">
-                  <span className="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
-                  <span
-                    className={cn(
-                      "text-[13px] font-medium",
-                      selectedAgentId === null ? "text-default" : "text-secondary",
-                    )}
-                  >
-                    All agents
-                  </span>
-                  <span className="flex-1" />
-                  <span className="text-[10px] text-muted tabular-nums font-mono">
-                    {agents.length}
-                  </span>
-                </div>
-              </button>
-            )}
-
-            {agents.map((agent) => {
-              const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
-              const isSelected = selectedAgentId === agent.id
-              const isRunning = agent.status === "running"
-              const isError = agent.status === "error"
-              const isStopped = agent.status === "stopped"
-
-              if (collapsed) {
-                return (
-                  <button
-                    key={agent.id}
-                    type="button"
-                    onClick={() => onSelectAgent(agent.id)}
-                    className={cn(
-                      "mx-auto my-0.5 relative group",
-                      isStopped && "opacity-55",
-                    )}
-                    title={agent.name}
-                  >
-                    <AgentAvatar name={agent.name} size="md" stopped={isStopped} />
-                    <span
-                      className={cn(
-                        "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface",
-                        config.dot,
-                        isRunning && "animate-breathe text-success",
-                      )}
-                    />
-                    {isSelected && (
-                      <span className="absolute inset-0 rounded-md ring-2 ring-accent/50" />
-                    )}
-                  </button>
-                )
-              }
-
-              return (
-                <button
-                  key={agent.id}
-                  type="button"
-                  onClick={() => onSelectAgent(agent.id)}
+                <span
                   className={cn(
-                    "group mx-1.5 rounded-lg transition-all duration-(--duration-normal) text-left",
-                    "border-l-2 border-transparent",
-                    isSelected && "bg-surface-raised/80 border-l-accent",
-                    !isSelected && "hover:bg-surface-raised/30",
-                    isError && !isSelected && "hover:bg-danger-subtle",
-                    isError && isSelected && "bg-danger-subtle/60 border-l-danger",
-                    isStopped && "opacity-55",
-                    isRunning && !isSelected && "animate-border-pulse",
+                    "h-1.5 w-1.5 rounded-full shrink-0",
+                    pill.dot,
+                    pill.animate && "animate-breathe text-success",
                   )}
-                >
-                  <div className="flex items-start gap-2 px-2.5 py-2">
-                    <AgentAvatar name={agent.name} stopped={isStopped} />
-                    <div className="flex-1 min-w-0">
-                      {/* Row 1: status dot + name + meta */}
-                      <div className="flex items-center gap-1.5">
-                        <span
-                          className={cn(
-                            "h-1.5 w-1.5 rounded-full shrink-0",
-                            config.dot,
-                            isRunning && "animate-breathe text-success",
-                          )}
-                        />
-                        <span
-                          className={cn(
-                            "text-[13px] font-medium truncate",
-                            isSelected ? "text-default" : "text-secondary",
-                            isStopped && "text-muted",
-                          )}
-                        >
-                          {agent.name}
-                        </span>
-                        <span className="flex-1" />
-                        {isError ? (
-                          <span className="text-[9px] font-semibold uppercase tracking-wide text-danger shrink-0">
-                            err
-                          </span>
-                        ) : (
-                          <span className="text-[10px] text-muted/60 shrink-0 tabular-nums font-mono">
-                            {agent.duration}
-                          </span>
-                        )}
-                      </div>
-                      {/* Row 2: activity + cost */}
-                      <div className="flex items-center gap-1 mt-px">
-                        <span
-                          className={cn(
-                            "text-[11px] truncate flex-1 leading-tight",
-                            isError ? "text-danger/80" : "text-muted/70",
-                          )}
-                        >
-                          {agent.task}
-                        </span>
-                        {agent.cost > 0 && (
-                          <span className="text-[9px] text-muted/50 font-mono shrink-0 tabular-nums">
-                            {formatCost(agent.cost)}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </button>
-              )
-            })}
-          </div>
-        </ScrollArea>
+                />
+                {statusCounts[pill.key]}
+              </span>
+            ),
+        )}
+      </div>
 
-        {/* Bottom bar */}
-        <div className="px-3 py-2 flex items-center shrink-0 border-t border-border-default">
-          {!collapsed && (
-            <span className="text-[11px] text-muted truncate">vahid@agentobox</span>
-          )}
+      {/* Bottom: secrets + user avatar */}
+      <div className="py-2 flex flex-col items-center gap-2 border-t border-border-default">
+        <button
+          type="button"
+          onClick={onOpenSecrets}
+          className="p-1.5 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+          title="Project secrets"
+        >
+          <KeyRound className="h-3.5 w-3.5" />
+        </button>
+        <div
+          className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold text-on-emphasis bg-accent"
+          title="vahid"
+        >
+          V
         </div>
       </div>
     </div>
@@ -1642,6 +1534,109 @@ function VncThumbnail({ agent }: { agent: FakeAgent }) {
   )
 }
 
+/* ================================================================== */
+/*  AGENT SETTINGS PANEL — config form inside expanded card            */
+/* ================================================================== */
+
+function AgentSettingsPanel({ agent }: { agent: FakeAgent }) {
+  const [model, setModel] = useState(agent.model)
+  const [instructions, setInstructions] = useState(agent.instructions)
+  const dirty = model !== agent.model || instructions !== agent.instructions
+
+  return (
+    <div className="px-3 py-3 space-y-3">
+      {/* Model selector */}
+      <div>
+        <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1">
+          Model
+        </label>
+        <select
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          className="w-full bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs text-default outline-none focus:border-accent/50 transition-colors"
+        >
+          <option>Opus 4.6</option>
+          <option>Sonnet 4.6</option>
+          <option>Haiku 4.5</option>
+        </select>
+      </div>
+
+      {/* Instructions textarea */}
+      <div>
+        <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1">
+          Instructions
+        </label>
+        <textarea
+          value={instructions}
+          onChange={(e) => setInstructions(e.target.value)}
+          rows={4}
+          className="w-full bg-surface-sunken/60 border border-border-default rounded-md px-2.5 py-1.5 text-xs font-mono text-default outline-none focus:border-accent/50 transition-colors resize-none"
+        />
+      </div>
+
+      {/* MCP Servers */}
+      <div>
+        <label className="block text-[10px] font-semibold uppercase tracking-wider text-muted mb-1">
+          MCP Servers
+        </label>
+        {agent.mcpServers.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {agent.mcpServers.map((server) => (
+              <span
+                key={server}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-surface-sunken/60 border border-border-subtle text-[11px] font-mono text-secondary"
+              >
+                {server}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="text-[11px] text-muted/50 font-mono">none configured</span>
+        )}
+      </div>
+
+      {/* Info line */}
+      <div className="text-[10px] text-muted font-mono">
+        Runtime: {agent.runtime} · Workspace: {agent.workspacePath}
+      </div>
+
+      {/* Restart banner */}
+      {dirty && (
+        <div className="flex items-center gap-2 px-2.5 py-2 rounded-md bg-warning-subtle/30 border border-warning/20">
+          <AlertTriangle className="h-3 w-3 text-warning shrink-0" />
+          <span className="text-[11px] text-warning">Changes require restart</span>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-accent/30 text-[11px] text-accent font-medium hover:bg-accent/10 transition-colors"
+        >
+          <RotateCcw className="h-3 w-3" />
+          Restart
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border-default text-[11px] text-secondary font-medium hover:bg-surface-sunken/40 transition-colors"
+        >
+          <RefreshCw className="h-3 w-3" />
+          Redeploy
+        </button>
+        <span className="flex-1" />
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-danger/30 text-[11px] text-danger font-medium hover:bg-danger-subtle/40 transition-colors"
+        >
+          <Trash2 className="h-3 w-3" />
+          Remove
+        </button>
+      </div>
+    </div>
+  )
+}
+
 /**
  * Agent card with two states:
  *
@@ -1659,11 +1654,13 @@ function VncThumbnail({ agent }: { agent: FakeAgent }) {
 function AgentCardRow({
   agent,
   isSelected,
+  isPreview = false,
   onSelect,
   compact = false,
 }: {
   agent: FakeAgent
   isSelected: boolean
+  isPreview?: boolean
   onSelect: () => void
   compact?: boolean
 }) {
@@ -1671,9 +1668,10 @@ function AgentCardRow({
   const isRunning = agent.status === "running"
   const isError = agent.status === "error"
   const isStopped = agent.status === "stopped"
+  const [detailTab, setDetailTab] = useState<"activity" | "settings">("activity")
 
   /* ---- COLLAPSED: compact single-row card ---- */
-  if (!isSelected) {
+  if (!isSelected && !isPreview) {
     return (
       <button
         type="button"
@@ -1725,7 +1723,86 @@ function AgentCardRow({
     )
   }
 
-  /* ---- EXPANDED: full card with VNC + detail feed ---- */
+  /* ---- Shared header for preview + expanded ---- */
+  const cardHeader = (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="w-full text-left"
+    >
+      <div className={cn("grid gap-2", compact ? "grid-cols-1 p-2.5" : "grid-cols-2 p-3")}>
+        {/* Left: agent info */}
+        <div className="min-w-0 flex flex-col">
+          {/* Header: avatar + name + status */}
+          <div className="flex items-center gap-2 mb-1.5">
+            <AgentAvatar name={agent.name} stopped={isStopped} />
+            <span className="text-[13px] font-medium flex-1 truncate text-default">
+              {agent.name}
+            </span>
+            <ChevronRight
+              size={14}
+              className={cn(
+                "shrink-0 text-muted transition-transform",
+                isSelected && "rotate-90",
+              )}
+            />
+            <span
+              className={cn(
+                "h-2 w-2 rounded-full shrink-0",
+                config.dot,
+                isRunning && "animate-breathe text-success",
+              )}
+            />
+          </div>
+
+          {/* Current task */}
+          <div className="flex items-start gap-1.5 mb-1">
+            <Terminal className="h-3 w-3 text-muted/60 shrink-0 mt-0.5" />
+            <span className="text-[11px] text-secondary leading-tight truncate">
+              {agent.task}
+            </span>
+          </div>
+
+          {/* Stats row */}
+          <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap">
+            <span className="inline-flex items-center gap-0.5">
+              <DollarSign className="h-2.5 w-2.5" />
+              {formatCost(agent.cost)}
+            </span>
+            <span className="inline-flex items-center gap-0.5">
+              <Clock className="h-2.5 w-2.5" />
+              {agent.duration}
+            </span>
+            <span className="text-muted/50">&middot;</span>
+            <span>{agent.model}</span>
+            <span className="text-muted/50">&middot;</span>
+            <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
+          </div>
+        </div>
+
+        {/* Right: VNC thumbnail */}
+        <VncThumbnail agent={agent} />
+      </div>
+    </button>
+  )
+
+  /* ---- PREVIEW: header + VNC only, no tabs/feed ---- */
+  if (isPreview && !isSelected) {
+    return (
+      <div
+        className={cn(
+          "rounded-lg border transition-all duration-(--duration-normal)",
+          "border-border-default bg-surface-raised/50",
+          isError && "border-danger/30",
+          isStopped && "opacity-60",
+        )}
+      >
+        {cardHeader}
+      </div>
+    )
+  }
+
+  /* ---- EXPANDED: full card with tabs + detail feed ---- */
   return (
     <div
       className={cn(
@@ -1734,66 +1811,39 @@ function AgentCardRow({
         isError && "border-danger/40",
       )}
     >
-      {/* Clickable header — click to collapse */}
-      <button
-        type="button"
-        onClick={onSelect}
-        className="w-full text-left"
-      >
-        <div className={cn("grid gap-2", compact ? "grid-cols-1 p-2.5" : "grid-cols-2 p-3")}>
-          {/* Left: agent info */}
-          <div className="min-w-0 flex flex-col">
-            {/* Header: avatar + name + status */}
-            <div className="flex items-center gap-2 mb-1.5">
-              <AgentAvatar name={agent.name} stopped={isStopped} />
-              <span className="text-[13px] font-medium flex-1 truncate text-default">
-                {agent.name}
-              </span>
-              <ChevronRight
-                size={14}
-                className="shrink-0 text-muted rotate-90 transition-transform"
-              />
-              <span
-                className={cn(
-                  "h-2 w-2 rounded-full shrink-0",
-                  config.dot,
-                  isRunning && "animate-breathe text-success",
-                )}
-              />
-            </div>
+      {cardHeader}
 
-            {/* Current task */}
-            <div className="flex items-start gap-1.5 mb-1">
-              <Terminal className="h-3 w-3 text-muted/60 shrink-0 mt-0.5" />
-              <span className="text-[11px] text-secondary leading-tight truncate">
-                {agent.task}
-              </span>
-            </div>
+      {/* Inline tab bar — Activity | Settings */}
+      <div className="flex items-center gap-1 px-3 py-1 border-t border-border-subtle bg-surface-sunken/20">
+        <button
+          type="button"
+          onClick={() => setDetailTab("activity")}
+          className={cn(
+            "px-2 py-1 rounded text-[11px] font-medium transition-colors",
+            detailTab === "activity" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
+          )}
+        >
+          Activity
+        </button>
+        <button
+          type="button"
+          onClick={() => setDetailTab("settings")}
+          className={cn(
+            "px-2 py-1 rounded text-[11px] font-medium transition-colors",
+            detailTab === "settings" ? "bg-surface-raised text-default" : "text-muted hover:text-secondary",
+          )}
+        >
+          <Settings className="h-3 w-3 inline mr-1" />
+          Settings
+        </button>
+      </div>
 
-            {/* Stats row */}
-            <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap">
-              <span className="inline-flex items-center gap-0.5">
-                <DollarSign className="h-2.5 w-2.5" />
-                {formatCost(agent.cost)}
-              </span>
-              <span className="inline-flex items-center gap-0.5">
-                <Clock className="h-2.5 w-2.5" />
-                {agent.duration}
-              </span>
-              <span className="text-muted/50">&middot;</span>
-              <span>{agent.model}</span>
-              <span className="text-muted/50">&middot;</span>
-              <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
-            </div>
-          </div>
-
-          {/* Right: VNC thumbnail */}
-          <VncThumbnail agent={agent} />
-        </div>
-      </button>
-
-      {/* Expanded detail feed — full verbose output from TimelineEntry.content */}
-      <AgentDetailFeed agent={agent} />
+      {/* Tab content */}
+      {detailTab === "activity" ? (
+        <AgentDetailFeed agent={agent} />
+      ) : (
+        <AgentSettingsPanel agent={agent} />
+      )}
     </div>
   )
 }
@@ -1957,11 +2007,13 @@ function AgentCardsPanel({
   selectedAgentId,
   onSelectAgent,
   compact = false,
+  allExpanded = false,
 }: {
   agents: FakeAgent[]
   selectedAgentId: string | null
   onSelectAgent: (id: string) => void
   compact?: boolean
+  allExpanded?: boolean
 }) {
   return (
     <ScrollArea className="h-full overflow-y-auto">
@@ -1971,6 +2023,7 @@ function AgentCardsPanel({
             key={agent.id}
             agent={agent}
             isSelected={selectedAgentId === agent.id}
+            isPreview={allExpanded && selectedAgentId !== agent.id}
             onSelect={() => onSelectAgent(agent.id)}
             compact={compact}
           />
@@ -2123,17 +2176,11 @@ function ResizeHandle({
 
 export default function PrototypePage() {
   const bp = useBreakpoint()
-  const [rosterCollapsed, setRosterCollapsed] = useState(false)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>("1")
   const [mainTab, setMainTab] = useState<"chat" | "agents">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
   const [rightPanelWidth, setRightPanelWidth] = useState<number | null>(null)
-
-  // Auto-collapse roster at M breakpoint
-  useEffect(() => {
-    if (bp === "M") setRosterCollapsed(true)
-    if (bp === "L" || bp === "XL") setRosterCollapsed(false)
-  }, [bp])
+  const [allExpanded, setAllExpanded] = useState(false)
 
   // Reset custom width when breakpoint changes
   useEffect(() => {
@@ -2145,16 +2192,12 @@ export default function PrototypePage() {
     [selectedAgentId],
   )
 
-  const handleSelectAgent = useCallback((id: string | null) => {
-    setSelectedAgentId(id)
-  }, [])
-
   const handleSelectAgentCard = useCallback((id: string) => {
     setSelectedAgentId((prev) => (prev === id ? null : id))
   }, [])
 
   // Determine what's visible at each breakpoint
-  const showRoster = bp !== "mobile"
+  const showIconRail = bp !== "mobile"
   const showRightPanel = bp === "XL" || bp === "L" || bp === "M"
   const showTopTabs = bp === "S" || bp === "mobile"
 
@@ -2184,12 +2227,10 @@ export default function PrototypePage() {
       <header>
         <h1 className="sr-only">Agentobox Dashboard</h1>
         <HeaderBar
-        onToggleSidebar={() => setRosterCollapsed((c) => !c)}
-        onOpenSecrets={() => setSecretsOpen(true)}
-        selectedAgent={selectedAgent}
-        agents={AGENTS}
-        showSidebarToggle={showRoster}
-      />
+          onOpenSecrets={() => setSecretsOpen(true)}
+          selectedAgent={selectedAgent}
+          agents={AGENTS}
+        />
       </header>
 
       {/* Secrets modal */}
@@ -2210,15 +2251,14 @@ export default function PrototypePage() {
 
       {/* Main layout */}
       <div className="flex-1 flex min-h-0 overflow-hidden">
-        {/* Roster */}
-        {showRoster && (
+        {/* Icon rail */}
+        {showIconRail && (
           <aside>
-            <RosterPanel
-              collapsed={rosterCollapsed || bp === "M"}
-              onToggle={() => setRosterCollapsed((c) => !c)}
+            <IconRail
               agents={AGENTS}
               selectedAgentId={selectedAgentId}
-              onSelectAgent={handleSelectAgent}
+              onSelectAgent={handleSelectAgentCard}
+              onOpenSecrets={() => setSecretsOpen(true)}
             />
           </aside>
         )}
@@ -2241,18 +2281,27 @@ export default function PrototypePage() {
           >
             <ResizeHandle onResize={handleRightPanelResize} onReset={() => setRightPanelWidth(null)} side="left" />
             <PanelHeader>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-1">
                 <Users className="h-3.5 w-3.5 text-muted" />
                 <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">
                   Agent Activity
                 </span>
               </div>
+              <button
+                type="button"
+                onClick={() => { setAllExpanded(prev => !prev); if (allExpanded) setSelectedAgentId(null); }}
+                className="p-1 rounded-md text-muted hover:text-secondary hover:bg-surface-raised/50 transition-colors"
+                title={allExpanded ? "Collapse all" : "Expand all"}
+              >
+                {allExpanded ? <ChevronsDownUp className="h-3.5 w-3.5" /> : <ChevronsUpDown className="h-3.5 w-3.5" />}
+              </button>
             </PanelHeader>
             <AgentCardsPanel
               agents={AGENTS}
               selectedAgentId={selectedAgentId}
               onSelectAgent={handleSelectAgentCard}
               compact={compactCards}
+              allExpanded={allExpanded}
             />
           </div>
         )}
@@ -2264,6 +2313,7 @@ export default function PrototypePage() {
               agents={AGENTS}
               selectedAgentId={selectedAgentId}
               onSelectAgent={handleSelectAgentCard}
+              allExpanded={allExpanded}
             />
           </div>
         )}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1753,58 +1753,53 @@ function AgentCardRow({
       onClick={onSelect}
       className="w-full text-left"
     >
-      <div className={cn("grid gap-2", compact ? "grid-cols-1 p-2.5" : "grid-cols-2 p-3")}>
-        {/* Left: agent info */}
-        <div className="min-w-0 flex flex-col">
-          {/* Header: avatar + name + status */}
-          <div className="flex items-center gap-2 mb-1.5">
-            <AgentAvatar name={agent.name} stopped={isStopped} />
-            <span className="text-[13px] font-medium flex-1 truncate text-default">
-              {agent.name}
-            </span>
-            <ChevronRight
-              size={14}
-              className={cn(
-                "shrink-0 text-muted transition-transform",
-                isSelected && "rotate-90",
-              )}
-            />
-            <span
-              className={cn(
-                "h-2 w-2 rounded-full shrink-0",
-                config.dot,
-                isRunning && "animate-breathe text-success",
-              )}
-            />
-          </div>
-
-          {/* Current task */}
-          <div className="flex items-start gap-1.5 mb-1">
-            <Terminal className="h-3 w-3 text-muted/60 shrink-0 mt-0.5" />
-            <span className="text-[11px] text-secondary leading-tight truncate">
-              {agent.task}
-            </span>
-          </div>
-
-          {/* Stats row */}
-          <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap">
-            <span className="inline-flex items-center gap-0.5">
-              <DollarSign className="h-2.5 w-2.5" />
-              {formatCost(agent.cost)}
-            </span>
-            <span className="inline-flex items-center gap-0.5">
-              <Clock className="h-2.5 w-2.5" />
-              {agent.duration}
-            </span>
-            <span className="text-muted/50">&middot;</span>
-            <span>{agent.model}</span>
-            <span className="text-muted/50">&middot;</span>
-            <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
-          </div>
+      {/* Row 1: avatar + name + task + chevron + status dot */}
+      <div className="flex items-center gap-2 px-3 pt-3 pb-2">
+        <AgentAvatar name={agent.name} stopped={isStopped} />
+        <span className="text-[13px] font-medium truncate text-default">
+          {agent.name}
+        </span>
+        <div className="flex items-center gap-1.5 flex-1 min-w-0">
+          <Terminal className="h-3 w-3 text-muted/60 shrink-0" />
+          <span className="text-[11px] text-secondary leading-tight truncate">
+            {agent.task}
+          </span>
         </div>
+        <ChevronRight
+          size={14}
+          className={cn(
+            "shrink-0 text-muted transition-transform",
+            isSelected && "rotate-90",
+          )}
+        />
+        <span
+          className={cn(
+            "h-2 w-2 rounded-full shrink-0",
+            config.dot,
+            isRunning && "animate-breathe text-success",
+          )}
+        />
+      </div>
 
-        {/* Right: VNC thumbnail */}
+      {/* Row 2: VNC full width */}
+      <div className="px-3 pb-2">
         <VncThumbnail agent={agent} />
+      </div>
+
+      {/* Row 3: Stats row */}
+      <div className="flex items-center gap-2 text-[9px] text-muted font-mono tabular-nums flex-wrap px-3 pb-2">
+        <span className="inline-flex items-center gap-0.5">
+          <DollarSign className="h-2.5 w-2.5" />
+          {formatCost(agent.cost)}
+        </span>
+        <span className="inline-flex items-center gap-0.5">
+          <Clock className="h-2.5 w-2.5" />
+          {agent.duration}
+        </span>
+        <span className="text-muted/50">&middot;</span>
+        <span>{agent.model}</span>
+        <span className="text-muted/50">&middot;</span>
+        <span>{agent.turns} turn{agent.turns !== 1 ? "s" : ""}</span>
       </div>
     </button>
   )
@@ -1835,6 +1830,9 @@ function AgentCardRow({
       )}
     >
       {cardHeader}
+
+      {/* Live status bar — card-level, visible regardless of tab */}
+      {isRunning && <LiveStatusBar agent={agent} />}
 
       {/* Inline tab bar — Activity | Settings */}
       <div className="flex items-center gap-1 px-3 py-1 border-t border-border-subtle bg-surface-sunken/20">
@@ -1983,9 +1981,6 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
           </div>
         )}
       </div>
-
-      {/* Live status bar — pinned between feed and composer */}
-      {isRunning && <LiveStatusBar agent={agent} />}
 
       {/* Mini composer — message this specific agent */}
       <div className="px-3 py-2 border-t border-border-subtle">

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -31,6 +31,7 @@ import {
   Search,
   Filter,
   Tag,
+  Shield,
 } from "lucide-react"
 import { cn, agentHue, formatCost } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -63,6 +64,7 @@ type FakeAgent = {
   runtime: "docker" | "modal"
   workspacePath: string
   tags: string[]
+  mode: "auto" | "plan" | "supervised"
 }
 
 const AGENTS: FakeAgent[] = [
@@ -84,6 +86,7 @@ const AGENTS: FakeAgent[] = [
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
     tags: ["backend", "core"],
+    mode: "plan",
   },
   {
     id: "2",
@@ -102,6 +105,7 @@ const AGENTS: FakeAgent[] = [
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
     tags: ["frontend", "core"],
+    mode: "auto",
   },
   {
     id: "3",
@@ -119,6 +123,7 @@ const AGENTS: FakeAgent[] = [
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
     tags: ["testing", "ci"],
+    mode: "supervised",
   },
   {
     id: "4",
@@ -135,6 +140,7 @@ const AGENTS: FakeAgent[] = [
     runtime: "modal",
     workspacePath: "/workspace/agentobox",
     tags: ["infra", "ci"],
+    mode: "auto",
   },
   {
     id: "5",
@@ -152,6 +158,7 @@ const AGENTS: FakeAgent[] = [
     runtime: "docker",
     workspacePath: "/workspace/agentobox",
     tags: ["docs"],
+    mode: "auto",
   },
   {
     id: "6",
@@ -168,6 +175,7 @@ const AGENTS: FakeAgent[] = [
     runtime: "modal",
     workspacePath: "/workspace/agentobox",
     tags: ["infra"],
+    mode: "supervised",
   },
 ]
 
@@ -343,6 +351,9 @@ type TeamFeedItem =
   | { type: "status"; agent: string; from: string; to: string }
   | { type: "error"; agent: string; text: string }
   | { type: "question"; agent: string; question: string; options: string[] }
+  | { type: "plan"; agent: string; title: string; steps: { text: string; status: "done" | "current" | "pending" }[]; planStatus: "pending" | "approved" | "rejected" }
+  | { type: "permission"; agent: string; command: string; risk?: string; permStatus: "pending" | "allowed" | "denied" }
+  | { type: "multi-question"; agent: string; questions: { text: string; options: string[] }[] }
 
 const TEAM_FEED: TeamFeedItem[] = [
   // Session start
@@ -358,6 +369,21 @@ const TEAM_FEED: TeamFeedItem[] = [
   { type: "status", agent: "qa", from: "idle", to: "waiting" },
   { type: "status", agent: "docs", from: "idle", to: "running" },
 
+  // Backend proposes a plan before starting work
+  {
+    type: "plan",
+    agent: "backend",
+    title: "Fix JWT validation and add clock skew tolerance",
+    steps: [
+      { text: "Read auth.ts and identify expiry comparison bug", status: "done" },
+      { text: "Convert Date.now() to seconds in validateToken()", status: "done" },
+      { text: "Add 30-second clock skew tolerance", status: "current" },
+      { text: "Add structured error logging for validation failures", status: "pending" },
+      { text: "Run lint and existing tests", status: "pending" },
+    ],
+    planStatus: "approved",
+  },
+
   // Backend finishes first turn — SUMMARY (not the full verbose output)
   {
     type: "summary",
@@ -366,6 +392,22 @@ const TEAM_FEED: TeamFeedItem[] = [
     cost: 0.08,
     turns: 5,
     duration: "2m 10s",
+  },
+
+  // Backend asks multiple questions about auth strategy
+  {
+    type: "multi-question",
+    agent: "backend",
+    questions: [
+      {
+        text: "Which token storage strategy should we use for refresh tokens?",
+        options: ["HTTP-only cookies", "In-memory + secure storage", "Session storage"],
+      },
+      {
+        text: "Should we enforce single-session or allow multiple concurrent sessions?",
+        options: ["Single session (revoke old on new login)", "Multiple sessions (up to 5)", "Unlimited sessions"],
+      },
+    ],
   },
 
   // Backend asks a question
@@ -424,6 +466,15 @@ const TEAM_FEED: TeamFeedItem[] = [
     duration: "2m 10s",
   },
 
+  // QA requests permission to push
+  {
+    type: "permission",
+    agent: "qa",
+    command: "git push origin fix/jwt-validation",
+    risk: "Pushes to remote branch",
+    permStatus: "pending",
+  },
+
   // Docs finishes
   {
     type: "summary",
@@ -463,6 +514,77 @@ const PILL_CONFIG = [
   { key: "idle" as const, dot: "bg-info", text: "text-muted" },
   { key: "stopped" as const, dot: "bg-muted/40", text: "text-muted/50" },
 ]
+
+const MODE_CONFIG = {
+  auto: { label: "auto", color: "text-success" },
+  plan: { label: "plan", color: "text-warning" },
+  supervised: { label: "supervised", color: "text-info" },
+} as const
+
+/* ================================================================== */
+/*  MODE PILL                                                          */
+/* ================================================================== */
+
+function ModePill({
+  mode,
+  onChange,
+}: {
+  mode: "auto" | "plan" | "supervised"
+  onChange: (mode: "auto" | "plan" | "supervised") => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const cfg = MODE_CONFIG[mode]
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("mousedown", handleClick)
+    return () => document.removeEventListener("mousedown", handleClick)
+  }, [open])
+
+  return (
+    <div className="relative shrink-0" ref={ref}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen(!open)
+        }}
+        className={cn("text-[10px] font-medium transition-colors hover:opacity-80", cfg.color)}
+      >
+        {cfg.label}
+      </button>
+      {open && (
+        <div
+          className="absolute top-full left-0 mt-1 w-28 rounded-md border border-border-default bg-surface-raised shadow-lg z-(--z-dropdown) overflow-hidden"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {(Object.keys(MODE_CONFIG) as Array<keyof typeof MODE_CONFIG>).map((key) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => {
+                onChange(key)
+                setOpen(false)
+              }}
+              className={cn(
+                "w-full text-left px-3 py-1.5 text-[11px] font-medium transition-colors",
+                mode === key
+                  ? cn(MODE_CONFIG[key].color, "bg-surface-sunken/40")
+                  : "text-secondary hover:bg-surface-sunken/40",
+              )}
+            >
+              {MODE_CONFIG[key].label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
 /* ================================================================== */
 /*  BREAKPOINT HOOK                                                    */
@@ -862,6 +984,318 @@ function QuestionCard({
           <p className="text-[10px] text-muted/50 mt-2 font-mono">
             or type a custom response...
           </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 7b. PlanCard — interactive plan approval card */
+function PlanCard({
+  agent,
+  title,
+  steps,
+  planStatus: initialStatus,
+}: {
+  agent: string
+  title: string
+  steps: { text: string; status: "done" | "current" | "pending" }[]
+  planStatus: "pending" | "approved" | "rejected"
+}) {
+  const [status, setStatus] = useState(initialStatus)
+
+  if (status === "approved") {
+    return (
+      <div className="flex items-center gap-2 py-0.5 justify-center">
+        <AgentAvatar name={agent} size="sm" />
+        <span className="text-[10px] font-mono text-success">
+          Plan: {title} <Check className="inline h-3 w-3" strokeWidth={2.5} /> approved
+        </span>
+      </div>
+    )
+  }
+
+  if (status === "rejected") {
+    return (
+      <div className="flex items-center gap-2 py-0.5 justify-center">
+        <AgentAvatar name={agent} size="sm" />
+        <span className="text-[10px] font-mono text-muted">
+          Plan: {title} <X className="inline h-3 w-3" strokeWidth={2.5} /> rejected
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-2 min-w-0">
+      <ChatAvatar name={agent} />
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-warning font-mono mb-0.5">{agent} · Proposing a plan</div>
+        <div className="rounded-lg border border-warning/20 bg-surface-raised/60 p-3 max-w-lg">
+          <p className="text-sm font-medium text-default mb-2">{title}</p>
+          <div className="space-y-1.5 mb-3">
+            {steps.map((step, i) => (
+              <div key={i} className="flex items-start gap-2">
+                {step.status === "done" ? (
+                  <Check className="h-3.5 w-3.5 text-success shrink-0 mt-0.5" strokeWidth={2.5} />
+                ) : step.status === "current" ? (
+                  <span className="h-3.5 w-3.5 flex items-center justify-center shrink-0 mt-0.5">
+                    <span className="h-2 w-2 rounded-full bg-warning animate-breathe" />
+                  </span>
+                ) : (
+                  <span className="h-3.5 w-3.5 rounded-full border border-border-default shrink-0 mt-0.5" />
+                )}
+                <span
+                  className={cn(
+                    "text-xs leading-tight",
+                    step.status === "done" && "text-muted line-through",
+                    step.status === "current" && "text-default font-medium",
+                    step.status === "pending" && "text-muted",
+                  )}
+                >
+                  {step.text}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setStatus("approved")}
+              className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => setStatus("rejected")}
+              className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 7c. PermissionCard — permission request card */
+function PermissionCard({
+  agent,
+  command,
+  risk,
+  permStatus: initialStatus,
+}: {
+  agent: string
+  command: string
+  risk?: string
+  permStatus: "pending" | "allowed" | "denied"
+}) {
+  const [status, setStatus] = useState(initialStatus)
+
+  if (status === "allowed") {
+    return (
+      <div className="flex items-center gap-2 py-0.5 justify-center">
+        <AgentAvatar name={agent} size="sm" />
+        <span className="text-[10px] font-mono text-success">
+          Allowed: <code className="bg-surface-sunken/60 px-1 rounded">{command}</code> <Check className="inline h-3 w-3" strokeWidth={2.5} />
+        </span>
+      </div>
+    )
+  }
+
+  if (status === "denied") {
+    return (
+      <div className="flex items-center gap-2 py-0.5 justify-center">
+        <AgentAvatar name={agent} size="sm" />
+        <span className="text-[10px] font-mono text-muted">
+          Denied: <code className="bg-surface-sunken/60 px-1 rounded">{command}</code> <X className="inline h-3 w-3" strokeWidth={2.5} />
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-2 min-w-0">
+      <ChatAvatar name={agent} />
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-info font-mono mb-0.5">
+          <Shield className="inline h-3 w-3 mr-1" />
+          {agent} · Requesting permission
+        </div>
+        <div className="rounded-lg border border-info/20 bg-surface-raised/60 p-3 max-w-lg">
+          <div className="rounded-md bg-surface-sunken/60 border border-border-subtle px-3 py-2 mb-2">
+            <code className="text-xs font-mono text-default">{command}</code>
+          </div>
+          {risk && (
+            <div className="flex items-center gap-1.5 mb-3">
+              <AlertTriangle className="h-3 w-3 text-warning shrink-0" />
+              <span className="text-[11px] text-warning">{risk}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setStatus("allowed")}
+              className="px-3 py-1.5 rounded-md border border-success/30 text-xs font-medium text-success hover:bg-success-subtle/40 transition-colors"
+            >
+              Allow
+            </button>
+            <button
+              type="button"
+              onClick={() => setStatus("allowed")}
+              className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
+            >
+              Allow always
+            </button>
+            <button
+              type="button"
+              onClick={() => setStatus("denied")}
+              className="px-3 py-1.5 rounded-md border border-danger/30 text-xs font-medium text-danger hover:bg-danger-subtle/40 transition-colors"
+            >
+              Deny
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 7d. MultiQuestionCard — tabbed multi-question card */
+function MultiQuestionCard({
+  agent,
+  questions,
+}: {
+  agent: string
+  questions: { text: string; options: string[] }[]
+}) {
+  const [currentStep, setCurrentStep] = useState(0)
+  const [answers, setAnswers] = useState<Record<number, number>>({})
+  const [submitted, setSubmitted] = useState(false)
+  const [reviewing, setReviewing] = useState(false)
+
+  if (submitted) {
+    return (
+      <div className="flex items-center gap-2 py-0.5 justify-center">
+        <AgentAvatar name={agent} size="sm" />
+        <span className="text-[10px] font-mono text-success">
+          Answered {questions.length} questions <Check className="inline h-3 w-3" strokeWidth={2.5} />
+        </span>
+      </div>
+    )
+  }
+
+  if (reviewing) {
+    return (
+      <div className="flex gap-2 min-w-0">
+        <ChatAvatar name={agent} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[11px] text-muted font-mono mb-0.5">{agent}</div>
+          <div className="rounded-lg border border-border-default bg-surface-raised/60 p-3 max-w-lg">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-default">Review answers</span>
+            </div>
+            <div className="space-y-2 mb-3">
+              {questions.map((q, i) => (
+                <div key={i} className="text-xs">
+                  <p className="text-muted mb-0.5">{q.text}</p>
+                  <p className="text-default font-medium">
+                    {answers[i] !== undefined ? q.options[answers[i]] : <span className="text-warning">unanswered</span>}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 pt-2 border-t border-border-subtle">
+              <button
+                type="button"
+                onClick={() => { setReviewing(false); setCurrentStep(0) }}
+                className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => setSubmitted(true)}
+                className="px-3 py-1.5 rounded-md bg-accent text-on-emphasis text-xs font-medium hover:bg-accent-hover transition-colors"
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const q = questions[currentStep]
+  const isLast = currentStep === questions.length - 1
+
+  return (
+    <div className="flex gap-2 min-w-0">
+      <ChatAvatar name={agent} />
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-muted font-mono mb-0.5">{agent}</div>
+        <div className="rounded-lg border border-border-default bg-surface-raised/60 p-3 max-w-lg">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm text-default">{q.text}</p>
+            <span className="text-[10px] text-muted font-mono shrink-0 ml-2">
+              {currentStep + 1} of {questions.length}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2 mb-3">
+            {q.options.map((opt, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setAnswers((prev) => ({ ...prev, [currentStep]: i }))}
+                className={cn(
+                  "px-3 py-1.5 rounded-md border text-xs font-medium transition-all",
+                  answers[currentStep] === i
+                    ? "border-accent bg-accent/15 text-accent"
+                    : "border-border-default text-secondary hover:border-border-strong hover:bg-surface-sunken/40",
+                )}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2 pt-2 border-t border-border-subtle">
+            {currentStep > 0 && (
+              <button
+                type="button"
+                onClick={() => setCurrentStep((s) => s - 1)}
+                className="px-3 py-1.5 rounded-md border border-border-default text-xs font-medium text-secondary hover:bg-surface-sunken/40 transition-colors"
+              >
+                Back
+              </button>
+            )}
+            <span className="flex-1" />
+            {isLast ? (
+              <button
+                type="button"
+                onClick={() => setReviewing(true)}
+                className="px-3 py-1.5 rounded-md bg-accent text-on-emphasis text-xs font-medium hover:bg-accent-hover transition-colors"
+              >
+                Review & Submit
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setCurrentStep((s) => s + 1)}
+                className="px-3 py-1.5 rounded-md border border-accent/30 text-xs font-medium text-accent hover:bg-accent/10 transition-colors"
+              >
+                Next →
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -1868,6 +2302,80 @@ function ComposerBar() {
 }
 
 /* ================================================================== */
+/*  ATTENTION BAR                                                      */
+/* ================================================================== */
+
+function AttentionBar({ items }: { items: TeamFeedItem[] }) {
+  const pending = items.filter((item): item is Extract<TeamFeedItem, { type: "permission" } | { type: "plan" }> => {
+    if (item.type === "permission" && item.permStatus === "pending") return true
+    if (item.type === "plan" && item.planStatus === "pending") return true
+    return false
+  })
+
+  if (pending.length === 0) return null
+
+  // Sort: permissions first, then plans
+  const sorted = [...pending].sort((a, b) => {
+    const order = { permission: 0, plan: 1 }
+    return (order[a.type] ?? 2) - (order[b.type] ?? 2)
+  })
+
+  return (
+    <div className="mx-6 mb-2 rounded-lg border border-warning/20 bg-warning-subtle/10 p-3 max-w-3xl self-center w-full">
+      <div className="flex items-center gap-2 mb-2">
+        <AlertTriangle className="h-3.5 w-3.5 text-warning shrink-0" />
+        <span className="text-xs font-medium text-warning">
+          {pending.length} item{pending.length !== 1 ? "s" : ""} need attention
+        </span>
+      </div>
+      <div className="space-y-1.5">
+        {sorted.map((item, i) => (
+          <div key={i} className="flex items-center gap-2 min-w-0">
+            <AgentAvatar name={item.agent} size="sm" />
+            <span className="text-[11px] text-secondary truncate flex-1 min-w-0">
+              {item.type === "permission"
+                ? `${item.agent} wants to run: ${item.command}`
+                : `${item.agent} proposed: ${item.title}`}
+            </span>
+            {item.type === "permission" ? (
+              <div className="flex items-center gap-1 shrink-0">
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                >
+                  Allow
+                </button>
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                >
+                  Deny
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1 shrink-0">
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                >
+                  Reject
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================== */
 /*  TEAM FEED — main feed renders team-level events only               */
 /*                                                                     */
 /*  This is the "slack channel" view. You see:                         */
@@ -1911,6 +2419,12 @@ function TeamFeed() {
                 return <TeamErrorAlert key={i} agent={item.agent} text={item.text} />
               case "question":
                 return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
+              case "plan":
+                return <PlanCard key={i} agent={item.agent} title={item.title} steps={item.steps} planStatus={item.planStatus} />
+              case "permission":
+                return <PermissionCard key={i} agent={item.agent} command={item.command} risk={item.risk} permStatus={item.permStatus} />
+              case "multi-question":
+                return <MultiQuestionCard key={i} agent={item.agent} questions={item.questions} />
               default:
                 return null
             }
@@ -1918,6 +2432,7 @@ function TeamFeed() {
         </div>
       </ScrollArea>
 
+      <AttentionBar items={TEAM_FEED} />
       <ComposerBar />
     </div>
   )
@@ -2294,6 +2809,13 @@ function AgentCardRow({
   const isError = agent.status === "error"
   const isStopped = agent.status === "stopped"
   const [viewMode, setViewMode] = useState<ViewMode>("terminal")
+  const [agentMode, setAgentMode] = useState(agent.mode)
+
+  const hasPendingItem = TEAM_FEED.some(
+    (item) =>
+      (item.type === "permission" && item.agent === agent.name && item.permStatus === "pending") ||
+      (item.type === "plan" && item.agent === agent.name && item.planStatus === "pending"),
+  )
 
   const VIEW_MODES: { id: ViewMode; icon: typeof Monitor; label: string }[] = [
     { id: "terminal", icon: Monitor, label: "Screen" },
@@ -2315,9 +2837,10 @@ function AgentCardRow({
             ),
       )}
     >
-      {/* Header row — always visible, click to toggle */}
-      <button
-        type="button"
+      {/* Header row — div instead of button to allow nested interactive ModePill */}
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => {
           if (selectable && onSelect) {
             onSelect()
@@ -2325,7 +2848,14 @@ function AgentCardRow({
             onToggle()
           }
         }}
-        className="w-full text-left px-2.5 py-2"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            if (selectable && onSelect) onSelect()
+            else onToggle()
+          }
+        }}
+        className="w-full text-left px-2.5 py-2 cursor-pointer"
       >
         <div className="flex items-center gap-2 min-w-0">
           {selectable && (
@@ -2349,14 +2879,15 @@ function AgentCardRow({
           >
             {agent.name}
           </span>
-          {/* Tag pills — show 1 + overflow count */}
+          <ModePill mode={agentMode} onChange={setAgentMode} />
+          {/* Tag pills — show 1 + overflow count, shrink before mode */}
           {agent.tags.length > 0 && (
-            <span className="inline-flex items-center gap-1 shrink-0">
-              <span className="px-1.5 py-px rounded text-[9px] font-mono text-muted bg-surface-sunken/60 border border-border-subtle">
+            <span className="inline-flex items-center gap-1 shrink min-w-0 overflow-hidden">
+              <span className="px-1.5 py-px rounded text-[9px] font-mono text-muted bg-surface-sunken/60 border border-border-subtle truncate">
                 {agent.tags[0]}
               </span>
               {agent.tags.length > 1 && (
-                <span className="text-[9px] text-muted/40 font-mono">+{agent.tags.length - 1}</span>
+                <span className="text-[9px] text-muted/40 font-mono shrink-0">+{agent.tags.length - 1}</span>
               )}
             </span>
           )}
@@ -2391,7 +2922,7 @@ function AgentCardRow({
             )}
           />
         </div>
-      </button>
+      </div>
 
       {/* Open content — animated reveal */}
       <Collapsible open={isOpen}>
@@ -2425,21 +2956,59 @@ function AgentCardRow({
             ))}
           </div>
 
-          {/* Mini composer */}
-          <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded border border-border-default bg-surface-sunken/40 px-2 py-1">
-            <span className="text-[9px] text-accent font-mono shrink-0">@{agent.name}</span>
-            <input
-              type="text"
-              placeholder="Message..."
-              className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
-            />
-            <button
-              type="button"
-              className="flex items-center justify-center h-4 w-4 rounded-full bg-surface text-muted shrink-0"
-            >
-              <ArrowUp className="h-2.5 w-2.5" strokeWidth={2.5} />
-            </button>
-          </div>
+          {/* Mini composer — transforms when agent has pending attention item */}
+          {hasPendingItem ? (
+            <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded border border-warning/30 bg-warning-subtle/10 px-2 py-1">
+              <Clock className="h-3 w-3 text-warning shrink-0" />
+              <span className="text-[11px] text-warning font-medium truncate flex-1 min-w-0">Needs attention</span>
+              {TEAM_FEED.some(item => item.type === "permission" && item.agent === agent.name && item.permStatus === "pending") ? (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    className="px-2 py-0.5 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                  >
+                    Allow
+                  </button>
+                  <button
+                    type="button"
+                    className="px-2 py-0.5 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                  >
+                    Deny
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    className="px-2 py-0.5 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    className="px-2 py-0.5 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                  >
+                    Reject
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="flex-1 flex items-center gap-1.5 min-w-0 rounded border border-border-default bg-surface-sunken/40 px-2 py-1">
+              <span className="text-[9px] text-accent font-mono shrink-0">@{agent.name}</span>
+              <input
+                type="text"
+                placeholder="Message..."
+                className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
+              />
+              <button
+                type="button"
+                className="flex items-center justify-center h-4 w-4 rounded-full bg-surface text-muted shrink-0"
+              >
+                <ArrowUp className="h-2.5 w-2.5" strokeWidth={2.5} />
+              </button>
+            </div>
+          )}
 
           {/* Todo progress */}
           {agent.todoProgress && (

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import { useState, useEffect, useCallback, useMemo, useRef, useReducer } from "react"
 import {
   ArrowUp,
   Users,
@@ -43,10 +43,14 @@ import { CopyButton } from "@/components/shared/copy-button"
 /*  FAKE DATA                                                          */
 /* ================================================================== */
 
+type LifecycleStatus = "deploying" | "running" | "waiting" | "error" | "idle" | "stopped"
+type AttentionLevel = "none" | "review" | "plan" | "permission"
+
 type FakeAgent = {
   id: string
   name: string
-  status: "running" | "error" | "idle" | "stopped" | "waiting" | "deploying"
+  lifecycleStatus: LifecycleStatus
+  attentionLevel: AttentionLevel
   task: string
   cost: number
   duration: string
@@ -67,11 +71,12 @@ type FakeAgent = {
   mode: "auto" | "plan" | "supervised"
 }
 
-const AGENTS: FakeAgent[] = [
+const INITIAL_AGENTS: FakeAgent[] = [
   {
     id: "1",
     name: "backend",
-    status: "running",
+    lifecycleStatus: "running",
+    attentionLevel: "none",
     task: "Editing auth.ts — fixing JWT validation",
     cost: 0.12,
     duration: "3m 22s",
@@ -91,7 +96,8 @@ const AGENTS: FakeAgent[] = [
   {
     id: "2",
     name: "frontend",
-    status: "running",
+    lifecycleStatus: "running",
+    attentionLevel: "none",
     task: "Reading component styles",
     cost: 0.08,
     duration: "1m 45s",
@@ -110,7 +116,8 @@ const AGENTS: FakeAgent[] = [
   {
     id: "3",
     name: "qa",
-    status: "error",
+    lifecycleStatus: "error",
+    attentionLevel: "permission",
     task: "npm test failed",
     cost: 0.05,
     duration: "2m 10s",
@@ -128,7 +135,8 @@ const AGENTS: FakeAgent[] = [
   {
     id: "4",
     name: "devops",
-    status: "idle",
+    lifecycleStatus: "waiting",
+    attentionLevel: "none",
     task: "Waiting for backend",
     cost: 0.03,
     duration: "5m 00s",
@@ -145,7 +153,8 @@ const AGENTS: FakeAgent[] = [
   {
     id: "5",
     name: "docs",
-    status: "stopped",
+    lifecycleStatus: "stopped",
+    attentionLevel: "review",
     task: "Completed README update",
     cost: 0.02,
     duration: "1m 30s",
@@ -163,7 +172,8 @@ const AGENTS: FakeAgent[] = [
   {
     id: "6",
     name: "infra",
-    status: "deploying" as const,
+    lifecycleStatus: "deploying",
+    attentionLevel: "none",
     task: "Provisioning container",
     cost: 0.00,
     duration: "0m 12s",
@@ -302,7 +312,7 @@ function getAgentSkills(agent: FakeAgent): Skill[] {
 }
 
 /** All unique tags across agents */
-const ALL_TAGS = Array.from(new Set(AGENTS.flatMap(a => a.tags))).sort()
+const ALL_TAGS = Array.from(new Set(INITIAL_AGENTS.flatMap(a => a.tags))).sort()
 
 /**
  * FAKE_MARKDOWN — used in right-panel agent detail feed.
@@ -491,29 +501,96 @@ const TEAM_FEED: TeamFeedItem[] = [
 ]
 
 /* ================================================================== */
-/*  STATUS CONFIG                                                      */
+/*  STATUS + ATTENTION CONFIG                                          */
 /* ================================================================== */
 
-const STATUS_CONFIG: Record<
-  string,
-  { dot: string; label: string; glow?: string; text?: string }
-> = {
-  running: { dot: "bg-success", label: "Running", glow: "text-success", text: "text-success" },
-  idle: { dot: "bg-info", label: "Idle", text: "text-info" },
-  waiting: { dot: "bg-warning", label: "Waiting", text: "text-warning" },
-  error: { dot: "bg-danger", label: "Error", text: "text-danger" },
-  stopped: { dot: "bg-muted/50", label: "Stopped", text: "text-muted" },
-  deploying: { dot: "bg-accent", label: "Starting", text: "text-accent" },
+const ATTENTION_PRIORITY: Record<AttentionLevel, number> = { none: 0, review: 1, plan: 2, permission: 3 }
+const LIFECYCLE_PRIORITY: Record<LifecycleStatus, number> = { stopped: 0, idle: 1, deploying: 2, waiting: 3, running: 4, error: 5 }
+
+const LIFECYCLE_CONFIG: Record<LifecycleStatus, { dot: string; label: string; text: string; glow?: string }> = {
+  running:   { dot: "bg-success",   label: "Running",  text: "text-success", glow: "text-success" },
+  idle:      { dot: "bg-info",      label: "Idle",     text: "text-info" },
+  waiting:   { dot: "bg-warning",   label: "Waiting",  text: "text-warning" },
+  error:     { dot: "bg-danger",    label: "Error",    text: "text-danger" },
+  stopped:   { dot: "bg-muted/50",  label: "Stopped",  text: "text-muted" },
+  deploying: { dot: "bg-accent",    label: "Starting", text: "text-accent" },
 }
 
-const PILL_CONFIG = [
-  { key: "error" as const, dot: "bg-danger", text: "text-danger" },
-  { key: "waiting" as const, dot: "bg-warning", text: "text-warning" },
-  { key: "running" as const, dot: "bg-success", text: "text-success", animate: true },
-  { key: "deploying" as const, dot: "bg-accent", text: "text-accent" },
-  { key: "idle" as const, dot: "bg-info", text: "text-muted" },
-  { key: "stopped" as const, dot: "bg-muted/40", text: "text-muted/50" },
-]
+const ATTENTION_CONFIG: Record<Exclude<AttentionLevel, "none">, { dot: string; label: string; text: string; pulse: boolean }> = {
+  review:     { dot: "bg-success", label: "Review",     text: "text-success", pulse: false },
+  plan:       { dot: "bg-warning", label: "Plan",       text: "text-warning", pulse: true },
+  permission: { dot: "bg-info",    label: "Permission", text: "text-info",    pulse: true },
+}
+
+// Display order for fleet health pills (highest priority first)
+const LIFECYCLE_PILL_ORDER: LifecycleStatus[] = ["error", "waiting", "running", "deploying", "idle", "stopped"]
+const ATTENTION_PILL_ORDER: (Exclude<AttentionLevel, "none">)[] = ["permission", "plan", "review"]
+
+/* ================================================================== */
+/*  UTILITY FUNCTIONS                                                   */
+/* ================================================================== */
+
+function getHighestAttention(agents: FakeAgent[]): AttentionLevel {
+  let highest: AttentionLevel = "none"
+  for (const a of agents) {
+    if (a.attentionLevel === "permission") return "permission" // early exit at max
+    if (ATTENTION_PRIORITY[a.attentionLevel] > ATTENTION_PRIORITY[highest]) {
+      highest = a.attentionLevel
+    }
+  }
+  return highest
+}
+
+type PendingItem = Extract<TeamFeedItem, { type: "permission" }> | Extract<TeamFeedItem, { type: "plan" }>
+
+function getPendingItemsForAgent(feedItems: TeamFeedItem[], agentName: string): PendingItem[] {
+  return feedItems.filter((item): item is PendingItem =>
+    (item.type === "permission" && item.agent === agentName && item.permStatus === "pending") ||
+    (item.type === "plan" && item.agent === agentName && item.planStatus === "pending"),
+  )
+}
+
+function getAllPendingItems(feedItems: TeamFeedItem[]): PendingItem[] {
+  return feedItems.filter((item): item is PendingItem =>
+    (item.type === "permission" && item.permStatus === "pending") ||
+    (item.type === "plan" && item.planStatus === "pending"),
+  )
+}
+
+function deriveAttentionFromFeed(feedItems: TeamFeedItem[], agentName: string): AttentionLevel {
+  const pending = getPendingItemsForAgent(feedItems, agentName)
+  let highest: AttentionLevel = "none"
+  for (const item of pending) {
+    const level: AttentionLevel = item.type === "permission" ? "permission" : "plan"
+    if (ATTENTION_PRIORITY[level] > ATTENTION_PRIORITY[highest]) highest = level
+  }
+  return highest
+}
+
+/* ================================================================== */
+/*  AGENT REDUCER                                                       */
+/* ================================================================== */
+
+type AgentAction =
+  | { type: "SET_LIFECYCLE"; agentId: string; status: LifecycleStatus }
+  | { type: "SET_ATTENTION"; agentId: string; level: AttentionLevel }
+  | { type: "ACKNOWLEDGE"; agentId: string }
+  | { type: "RESET" }
+
+function agentReducer(state: FakeAgent[], action: AgentAction): FakeAgent[] {
+  switch (action.type) {
+    case "SET_LIFECYCLE":
+      return state.map(a => a.id === action.agentId ? { ...a, lifecycleStatus: action.status } : a)
+    case "SET_ATTENTION":
+      return state.map(a => a.id === action.agentId ? { ...a, attentionLevel: action.level } : a)
+    case "ACKNOWLEDGE":
+      return state.map(a => a.id === action.agentId && a.attentionLevel === "review" ? { ...a, attentionLevel: "none" } : a)
+    case "RESET":
+      return INITIAL_AGENTS
+    default:
+      return state
+  }
+}
 
 const MODE_CONFIG = {
   auto: { label: "auto", color: "text-success" },
@@ -1459,7 +1536,7 @@ function AgentSummaryCard({
  * SOURCE: StreamEvent status change (agent.status field transitions)
  */
 function AgentStatusLine({ agent, from, to }: { agent: string; from: string; to: string }) {
-  const toConfig = STATUS_CONFIG[to] ?? STATUS_CONFIG.stopped
+  const toConfig = LIFECYCLE_CONFIG[to as LifecycleStatus] ?? LIFECYCLE_CONFIG.stopped
 
   return (
     <div className="flex items-center justify-center gap-2 py-0.5">
@@ -1558,7 +1635,7 @@ function SecretsModal({
 
   if (!open) return null
 
-  const activeAgents = agents.filter((a) => a.status === "running" || a.status === "idle" || a.status === "deploying")
+  const activeAgents = agents.filter((a) => a.lifecycleStatus === "running" || a.lifecycleStatus === "idle" || a.lifecycleStatus === "deploying")
   const needsRestart = dirty && !restarted
 
   const toggleReveal = (id: string) => {
@@ -1764,15 +1841,30 @@ function SecretsModal({
 /* ================================================================== */
 
 function FleetHealthPills({
-  statusCounts,
+  agents,
   layout,
 }: {
-  statusCounts: Record<string, number>
+  agents: FakeAgent[]
   layout: "vertical" | "horizontal"
 }) {
-  const pills = PILL_CONFIG.filter((p) => (statusCounts[p.key] ?? 0) > 0)
+  const lifecycleCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const a of agents) counts[a.lifecycleStatus] = (counts[a.lifecycleStatus] ?? 0) + 1
+    return counts
+  }, [agents])
 
-  if (pills.length === 0) return null
+  const attentionCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const a of agents) {
+      if (a.attentionLevel !== "none") counts[a.attentionLevel] = (counts[a.attentionLevel] ?? 0) + 1
+    }
+    return counts
+  }, [agents])
+
+  const lifecyclePills = LIFECYCLE_PILL_ORDER.filter((k) => (lifecycleCounts[k] ?? 0) > 0)
+  const attentionPills = ATTENTION_PILL_ORDER.filter((k) => (attentionCounts[k] ?? 0) > 0)
+
+  if (lifecyclePills.length === 0 && attentionPills.length === 0) return null
 
   return (
     <div
@@ -1781,24 +1873,61 @@ function FleetHealthPills({
         layout === "vertical" ? "flex-col" : "flex-row gap-2",
       )}
     >
-      {pills.map((pill) => (
-        <span
-          key={pill.key}
-          className={cn(
-            "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
-            pill.text,
-          )}
-        >
+      {/* Lifecycle pills */}
+      {lifecyclePills.map((key) => {
+        const cfg = LIFECYCLE_CONFIG[key]
+        return (
           <span
+            key={key}
             className={cn(
-              "h-1.5 w-1.5 rounded-full shrink-0",
-              pill.dot,
-              pill.animate && "animate-breathe text-success",
+              "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
+              cfg.text,
             )}
-          />
-          {statusCounts[pill.key]}
-        </span>
-      ))}
+          >
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full shrink-0",
+                cfg.dot,
+                key === "running" && "animate-breathe text-success",
+              )}
+            />
+            {lifecycleCounts[key]}
+          </span>
+        )
+      })}
+
+      {/* Separator + attention pills */}
+      {attentionPills.length > 0 && (
+        <>
+          {lifecyclePills.length > 0 && (
+            <span className="text-muted/30 text-[9px]">&middot;</span>
+          )}
+          {attentionPills.map((key) => {
+            const cfg = ATTENTION_CONFIG[key]
+            return (
+              <span
+                key={key}
+                className={cn(
+                  "inline-flex items-center gap-0.5 font-mono text-[9px] tabular-nums",
+                  cfg.text,
+                )}
+              >
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full shrink-0",
+                    cfg.dot,
+                    cfg.pulse && "animate-breathe",
+                  )}
+                />
+                {attentionCounts[key]}
+                {layout === "horizontal" && (
+                  <span className="ml-0.5">{cfg.label.toLowerCase()}</span>
+                )}
+              </span>
+            )
+          })}
+        </>
+      )}
     </div>
   )
 }
@@ -1818,6 +1947,9 @@ function AgentLeftPanel({
   width,
   onResize,
   onResetWidth,
+  feedItems,
+  onResolvePermission,
+  onResolvePlan,
 }: {
   agents: FakeAgent[]
   expandedIds: Set<string>
@@ -1829,6 +1961,9 @@ function AgentLeftPanel({
   width: number
   onResize: (delta: number) => void
   onResetWidth: () => void
+  feedItems: TeamFeedItem[]
+  onResolvePermission: (feedIndex: number, verdict: "allowed" | "denied") => void
+  onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
 }) {
   const [panelTab, setPanelTab] = useState<"agents" | "skills">("agents")
   const [searchQuery, setSearchQuery] = useState("")
@@ -1837,12 +1972,6 @@ function AgentLeftPanel({
   const [selectMode, setSelectMode] = useState(false)
   const [showTagDropdown, setShowTagDropdown] = useState(false)
   const [skillsAllExpanded, setSkillsAllExpanded] = useState(false)
-
-  const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = { running: 0, error: 0, idle: 0, stopped: 0, waiting: 0, deploying: 0 }
-    for (const a of agents) counts[a.status] = (counts[a.status] ?? 0) + 1
-    return counts
-  }, [agents])
 
   const totalCost = useMemo(() => agents.reduce((sum, a) => sum + a.cost, 0), [agents])
 
@@ -1894,10 +2023,12 @@ function AgentLeftPanel({
         {/* Agent avatars */}
         <div className="flex-1 flex flex-col items-center gap-1.5 py-2 overflow-y-auto">
           {agents.map((agent) => {
-            const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
+            const config = LIFECYCLE_CONFIG[agent.lifecycleStatus]
             const isSelected = expandedIds.has(agent.id)
-            const isRunning = agent.status === "running"
-            const isStopped = agent.status === "stopped"
+            const isRunning = agent.lifecycleStatus === "running"
+            const isStopped = agent.lifecycleStatus === "stopped"
+            const hasAttention = agent.attentionLevel !== "none"
+            const attCfg = hasAttention ? ATTENTION_CONFIG[agent.attentionLevel as Exclude<AttentionLevel, "none">] : null
 
             return (
               <button
@@ -1914,13 +2045,24 @@ function AgentLeftPanel({
                 title={agent.name}
               >
                 <AgentAvatar name={agent.name} size="md" stopped={isStopped} />
-                <span
-                  className={cn(
-                    "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface-sunken",
-                    config.dot,
-                    isRunning && "animate-breathe text-success",
-                  )}
-                />
+                {/* Attention dot takes precedence over lifecycle dot */}
+                {hasAttention && attCfg ? (
+                  <span
+                    className={cn(
+                      "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface-sunken",
+                      attCfg.dot,
+                      attCfg.pulse && "animate-breathe",
+                    )}
+                  />
+                ) : (
+                  <span
+                    className={cn(
+                      "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border-2 border-surface-sunken",
+                      config.dot,
+                      isRunning && "animate-breathe text-success",
+                    )}
+                  />
+                )}
                 {isSelected && (
                   <span className="absolute inset-0 rounded-md ring-2 ring-accent/50" />
                 )}
@@ -1931,7 +2073,7 @@ function AgentLeftPanel({
 
         {/* Fleet health */}
         <div className="py-2 flex flex-col items-center gap-1 border-t border-border-subtle">
-          <FleetHealthPills statusCounts={statusCounts} layout="vertical" />
+          <FleetHealthPills agents={agents} layout="vertical" />
         </div>
 
         {/* Expand button — explicit affordance */}
@@ -2150,6 +2292,9 @@ function AgentLeftPanel({
                   selectable={selectMode}
                   selected={selectedIds.has(agent.id)}
                   onSelect={() => handleSelectAgent(agent.id)}
+                  pendingItems={getPendingItemsForAgent(feedItems, agent.name)}
+                  onResolvePermission={onResolvePermission}
+                  onResolvePlan={onResolvePlan}
                 />
               ))}
               {filteredAgents.length === 0 && (
@@ -2213,7 +2358,7 @@ function AgentLeftPanel({
 
           {/* Fleet health horizontal */}
           <div className="px-3 py-1.5 border-t border-border-subtle flex items-center gap-2 shrink-0">
-            <FleetHealthPills statusCounts={statusCounts} layout="horizontal" />
+            <FleetHealthPills agents={agents} layout="horizontal" />
             <span className="text-[9px] text-muted/40 font-mono ml-auto">
               {agents.length} agents
             </span>
@@ -2305,11 +2450,30 @@ function ComposerBar() {
 /*  ATTENTION BAR                                                      */
 /* ================================================================== */
 
-function AttentionBar({ items }: { items: TeamFeedItem[] }) {
-  const pending = items.filter((item): item is Extract<TeamFeedItem, { type: "permission" } | { type: "plan" }> => {
-    if (item.type === "permission" && item.permStatus === "pending") return true
-    if (item.type === "plan" && item.planStatus === "pending") return true
-    return false
+function AttentionBar({
+  feedItems,
+  focusedAgentId,
+  agents,
+  onResolvePermission,
+  onResolvePlan,
+}: {
+  feedItems: TeamFeedItem[]
+  focusedAgentId: string | null
+  agents: FakeAgent[]
+  onResolvePermission: (feedIndex: number, verdict: "allowed" | "denied") => void
+  onResolvePlan: (feedIndex: number, verdict: "approved" | "rejected") => void
+}) {
+  // Collect pending items with their original feed index for resolution
+  const pending: { item: PendingItem; feedIndex: number; agentId?: string }[] = []
+  feedItems.forEach((item, i) => {
+    if (item.type === "permission" && item.permStatus === "pending") {
+      const agent = agents.find(a => a.name === item.agent)
+      pending.push({ item: item as PendingItem, feedIndex: i, agentId: agent?.id })
+    }
+    if (item.type === "plan" && item.planStatus === "pending") {
+      const agent = agents.find(a => a.name === item.agent)
+      pending.push({ item: item as PendingItem, feedIndex: i, agentId: agent?.id })
+    }
   })
 
   if (pending.length === 0) return null
@@ -2317,7 +2481,7 @@ function AttentionBar({ items }: { items: TeamFeedItem[] }) {
   // Sort: permissions first, then plans
   const sorted = [...pending].sort((a, b) => {
     const order = { permission: 0, plan: 1 }
-    return (order[a.type] ?? 2) - (order[b.type] ?? 2)
+    return (order[a.item.type] ?? 2) - (order[b.item.type] ?? 2)
   })
 
   return (
@@ -2329,47 +2493,55 @@ function AttentionBar({ items }: { items: TeamFeedItem[] }) {
         </span>
       </div>
       <div className="space-y-1.5">
-        {sorted.map((item, i) => (
-          <div key={i} className="flex items-center gap-2 min-w-0">
-            <AgentAvatar name={item.agent} size="sm" />
-            <span className="text-[11px] text-secondary truncate flex-1 min-w-0">
-              {item.type === "permission"
-                ? `${item.agent} wants to run: ${item.command}`
-                : `${item.agent} proposed: ${item.title}`}
-            </span>
-            {item.type === "permission" ? (
-              <div className="flex items-center gap-1 shrink-0">
-                <button
-                  type="button"
-                  className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-                >
-                  Allow
-                </button>
-                <button
-                  type="button"
-                  className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-                >
-                  Deny
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center gap-1 shrink-0">
-                <button
-                  type="button"
-                  className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-                >
-                  Approve
-                </button>
-                <button
-                  type="button"
-                  className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-                >
-                  Reject
-                </button>
-              </div>
-            )}
-          </div>
-        ))}
+        {sorted.map(({ item, feedIndex, agentId }) => {
+          // Suppression: dim items for the focused agent
+          const isFocused = focusedAgentId != null && agentId === focusedAgentId
+          return (
+            <div key={feedIndex} className={cn("flex items-center gap-2 min-w-0", isFocused && "opacity-50")}>
+              <AgentAvatar name={item.agent} size="sm" />
+              <span className="text-[11px] text-secondary truncate flex-1 min-w-0">
+                {item.type === "permission"
+                  ? `${item.agent} wants to run: ${item.command}`
+                  : `${item.agent} proposed: ${item.title}`}
+              </span>
+              {item.type === "permission" ? (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => onResolvePermission(feedIndex, "allowed")}
+                    className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                  >
+                    Allow
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onResolvePermission(feedIndex, "denied")}
+                    className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                  >
+                    Deny
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => onResolvePlan(feedIndex, "approved")}
+                    className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onResolvePlan(feedIndex, "rejected")}
+                    className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+                  >
+                    Reject
+                  </button>
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )
@@ -2390,51 +2562,46 @@ function AttentionBar({ items }: { items: TeamFeedItem[] }) {
 /*  messages, tool results. Those live in the right panel detail view. */
 /* ================================================================== */
 
-function TeamFeed() {
+function TeamFeed({ feedItems }: { feedItems: TeamFeedItem[] }) {
   return (
-    <div className="flex flex-col h-full min-w-0">
-      <ScrollArea className="flex-1 overflow-y-auto dotted-grid">
-        <div className="max-w-3xl mx-auto w-full px-6 py-4 space-y-3">
-          {TEAM_FEED.map((item, i) => {
-            switch (item.type) {
-              case "system":
-                return <SystemMessage key={i} text={item.text} />
-              case "user":
-                return <TeamUserMessage key={i} text={item.text} target={item.target} />
-              case "summary":
-                return (
-                  <AgentSummaryCard
-                    key={i}
-                    agent={item.agent}
-                    summary={item.summary}
-                    cost={item.cost}
-                    turns={item.turns}
-                    duration={item.duration}
-                    isError={item.isError}
-                  />
-                )
-              case "status":
-                return <AgentStatusLine key={i} agent={item.agent} from={item.from} to={item.to} />
-              case "error":
-                return <TeamErrorAlert key={i} agent={item.agent} text={item.text} />
-              case "question":
-                return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
-              case "plan":
-                return <PlanCard key={i} agent={item.agent} title={item.title} steps={item.steps} planStatus={item.planStatus} />
-              case "permission":
-                return <PermissionCard key={i} agent={item.agent} command={item.command} risk={item.risk} permStatus={item.permStatus} />
-              case "multi-question":
-                return <MultiQuestionCard key={i} agent={item.agent} questions={item.questions} />
-              default:
-                return null
-            }
-          })}
-        </div>
-      </ScrollArea>
-
-      <AttentionBar items={TEAM_FEED} />
-      <ComposerBar />
-    </div>
+    <ScrollArea className="flex-1 overflow-y-auto dotted-grid">
+      <div className="max-w-3xl mx-auto w-full px-6 py-4 space-y-3">
+        {feedItems.map((item, i) => {
+          switch (item.type) {
+            case "system":
+              return <SystemMessage key={i} text={item.text} />
+            case "user":
+              return <TeamUserMessage key={i} text={item.text} target={item.target} />
+            case "summary":
+              return (
+                <AgentSummaryCard
+                  key={i}
+                  agent={item.agent}
+                  summary={item.summary}
+                  cost={item.cost}
+                  turns={item.turns}
+                  duration={item.duration}
+                  isError={item.isError}
+                />
+              )
+            case "status":
+              return <AgentStatusLine key={i} agent={item.agent} from={item.from} to={item.to} />
+            case "error":
+              return <TeamErrorAlert key={i} agent={item.agent} text={item.text} />
+            case "question":
+              return <QuestionCard key={i} agent={item.agent} question={item.question} options={item.options} />
+            case "plan":
+              return <PlanCard key={i} agent={item.agent} title={item.title} steps={item.steps} planStatus={item.planStatus} />
+            case "permission":
+              return <PermissionCard key={i} agent={item.agent} command={item.command} risk={item.risk} permStatus={item.permStatus} />
+            case "multi-question":
+              return <MultiQuestionCard key={i} agent={item.agent} questions={item.questions} />
+            default:
+              return null
+          }
+        })}
+      </div>
+    </ScrollArea>
   )
 }
 
@@ -2445,8 +2612,8 @@ function TeamFeed() {
 
 /** VNC thumbnail placeholder — aspect ratio matches a 16:10 display */
 function VncThumbnail({ agent }: { agent: FakeAgent }) {
-  const isRunning = agent.status === "running"
-  const isStopped = agent.status === "stopped"
+  const isRunning = agent.lifecycleStatus === "running"
+  const isStopped = agent.lifecycleStatus === "stopped"
 
   return (
     <div
@@ -2466,7 +2633,7 @@ function VncThumbnail({ agent }: { agent: FakeAgent }) {
             <span className="h-1.5 w-1.5 rounded-full bg-warning/60" />
             <span className="h-1.5 w-1.5 rounded-full bg-success/60" />
             <span className="ml-2 text-[7px] text-muted/40 font-mono truncate">
-              {agent.name} — {isRunning ? agent.task : isStopped ? "session ended" : agent.status}
+              {agent.name} — {isRunning ? agent.task : isStopped ? "session ended" : agent.lifecycleStatus}
             </span>
           </div>
           {/* Fake terminal content */}
@@ -2483,13 +2650,13 @@ function VncThumbnail({ agent }: { agent: FakeAgent }) {
               <div className="flex items-center justify-center h-full">
                 <span className="text-[7px] font-mono text-muted/20">session ended</span>
               </div>
-            ) : agent.status === "error" ? (
+            ) : agent.lifecycleStatus === "error" ? (
               <div className="space-y-0.5">
                 <p className="text-[6px] font-mono text-danger/50 leading-tight">Error: {agent.task}</p>
               </div>
             ) : (
               <div className="flex items-center justify-center h-full">
-                <span className="text-[7px] font-mono text-muted/25">{agent.status}</span>
+                <span className="text-[7px] font-mono text-muted/25">{agent.lifecycleStatus}</span>
               </div>
             )}
           </div>
@@ -2796,6 +2963,9 @@ function AgentCardRow({
   selectable = false,
   selected = false,
   onSelect,
+  pendingItems = [],
+  onResolvePermission,
+  onResolvePlan,
 }: {
   agent: FakeAgent
   isOpen: boolean
@@ -2803,19 +2973,20 @@ function AgentCardRow({
   selectable?: boolean
   selected?: boolean
   onSelect?: () => void
+  pendingItems?: PendingItem[]
+  onResolvePermission?: (index: number, verdict: "allowed" | "denied") => void
+  onResolvePlan?: (index: number, verdict: "approved" | "rejected") => void
 }) {
-  const config = STATUS_CONFIG[agent.status] ?? STATUS_CONFIG.stopped
-  const isRunning = agent.status === "running"
-  const isError = agent.status === "error"
-  const isStopped = agent.status === "stopped"
+  const config = LIFECYCLE_CONFIG[agent.lifecycleStatus]
+  const isRunning = agent.lifecycleStatus === "running"
+  const isError = agent.lifecycleStatus === "error"
+  const isStopped = agent.lifecycleStatus === "stopped"
   const [viewMode, setViewMode] = useState<ViewMode>("terminal")
   const [agentMode, setAgentMode] = useState(agent.mode)
 
-  const hasPendingItem = TEAM_FEED.some(
-    (item) =>
-      (item.type === "permission" && item.agent === agent.name && item.permStatus === "pending") ||
-      (item.type === "plan" && item.agent === agent.name && item.planStatus === "pending"),
-  )
+  const hasAttention = agent.attentionLevel !== "none"
+  const attCfg = hasAttention ? ATTENTION_CONFIG[agent.attentionLevel as Exclude<AttentionLevel, "none">] : null
+  const hasPendingItem = pendingItems.length > 0
 
   const VIEW_MODES: { id: ViewMode; icon: typeof Monitor; label: string }[] = [
     { id: "terminal", icon: Monitor, label: "Screen" },
@@ -2870,7 +3041,19 @@ function AgentCardRow({
               {selected && <Check className="h-2.5 w-2.5 text-accent" strokeWidth={3} />}
             </div>
           )}
-          <AgentAvatar name={agent.name} size="sm" stopped={isStopped} />
+          <div className="relative shrink-0">
+            <AgentAvatar name={agent.name} size="sm" stopped={isStopped} />
+            {/* Attention dot overlay on avatar — takes precedence over lifecycle */}
+            {hasAttention && attCfg && (
+              <span
+                className={cn(
+                  "absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full border border-surface",
+                  attCfg.dot,
+                  attCfg.pulse && "animate-breathe",
+                )}
+              />
+            )}
+          </div>
           <span
             className={cn(
               "text-[12px] font-medium shrink-0",
@@ -2937,11 +3120,7 @@ function AgentCardRow({
         {/* Bottom toolbar — swaps entirely when agent needs attention */}
         {hasPendingItem ? (
           <div className="border-t border-warning/20 bg-warning-subtle/10 px-3 py-2">
-            {TEAM_FEED.filter(
-              (item): item is Extract<TeamFeedItem, { type: "permission" } | { type: "plan" }> =>
-                (item.type === "permission" && item.agent === agent.name && item.permStatus === "pending") ||
-                (item.type === "plan" && item.agent === agent.name && item.planStatus === "pending"),
-            ).map((item, i) => (
+            {pendingItems.map((item, i) => (
               <div key={i} className="flex items-center gap-2 min-w-0">
                 <Shield className="h-3.5 w-3.5 text-warning shrink-0" />
                 <span className="text-[11px] text-warning font-medium truncate flex-1 min-w-0">
@@ -2953,12 +3132,14 @@ function AgentCardRow({
                   <div className="flex items-center gap-1.5 shrink-0">
                     <button
                       type="button"
+                      onClick={() => onResolvePermission?.(i, "allowed")}
                       className="px-2.5 py-1 rounded-md text-[11px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
                     >
                       Allow
                     </button>
                     <button
                       type="button"
+                      onClick={() => onResolvePermission?.(i, "denied")}
                       className="px-2.5 py-1 rounded-md text-[11px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
                     >
                       Deny
@@ -2968,12 +3149,14 @@ function AgentCardRow({
                   <div className="flex items-center gap-1.5 shrink-0">
                     <button
                       type="button"
+                      onClick={() => onResolvePlan?.(i, "approved")}
                       className="px-2.5 py-1 rounded-md text-[11px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
                     >
                       Approve
                     </button>
                     <button
                       type="button"
+                      onClick={() => onResolvePlan?.(i, "rejected")}
                       className="px-2.5 py-1 rounded-md text-[11px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
                     >
                       Reject
@@ -3046,8 +3229,8 @@ function AgentCardRow({
  *   thinking blocks, tool_result blocks. Everything the team feed hides.
  */
 function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
-  const isRunning = agent.status === "running"
-  const isError = agent.status === "error"
+  const isRunning = agent.lifecycleStatus === "running"
+  const isError = agent.lifecycleStatus === "error"
 
   return (
     <div className="border-t border-border-subtle flex flex-col">
@@ -3135,7 +3318,7 @@ function AgentDetailFeed({ agent }: { agent: FakeAgent }) {
           /* Generic fallback for devops, infra, etc. */
           <div className="flex items-center justify-center py-4">
             <span className="text-[10px] text-muted/50 font-mono">
-              {agent.status === "deploying" ? "Initializing workspace..." : "No activity yet"}
+              {agent.lifecycleStatus === "deploying" ? "Initializing workspace..." : "No activity yet"}
             </span>
           </div>
         )}
@@ -3452,10 +3635,16 @@ function AgentCardsPanel({
   agents,
   expandedIds,
   onToggleAgent,
+  feedItems,
+  onResolvePermission,
+  onResolvePlan,
 }: {
   agents: FakeAgent[]
   expandedIds: Set<string>
   onToggleAgent: (id: string) => void
+  feedItems?: TeamFeedItem[]
+  onResolvePermission?: (feedIndex: number, verdict: "allowed" | "denied") => void
+  onResolvePlan?: (feedIndex: number, verdict: "approved" | "rejected") => void
 }) {
   return (
     <ScrollArea className="h-full overflow-y-auto">
@@ -3466,6 +3655,9 @@ function AgentCardsPanel({
             agent={agent}
             isOpen={expandedIds.has(agent.id)}
             onToggle={() => onToggleAgent(agent.id)}
+            pendingItems={feedItems ? getPendingItemsForAgent(feedItems, agent.name) : []}
+            onResolvePermission={onResolvePermission}
+            onResolvePlan={onResolvePlan}
           />
         ))}
       </div>
@@ -3481,31 +3673,41 @@ function TabBar({
   tabs,
   activeTab,
   onTabChange,
+  badges,
 }: {
   tabs: { id: string; label: string; icon: React.ReactNode }[]
   activeTab: string
   onTabChange: (id: string) => void
+  badges?: Record<string, number>
 }) {
   return (
     <div role="tablist" className="h-8 flex items-center gap-1 px-3 border-b border-border-default bg-surface shrink-0">
-      {tabs.map((tab) => (
-        <button
-          key={tab.id}
-          type="button"
-          role="tab"
-          aria-selected={activeTab === tab.id}
-          onClick={() => onTabChange(tab.id)}
-          className={cn(
-            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
-            activeTab === tab.id
-              ? "bg-surface-raised text-default"
-              : "text-muted hover:text-secondary hover:bg-surface-raised/30",
-          )}
-        >
-          {tab.icon}
-          {tab.label}
-        </button>
-      ))}
+      {tabs.map((tab) => {
+        const badge = badges?.[tab.id] ?? 0
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            onClick={() => onTabChange(tab.id)}
+            className={cn(
+              "relative inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+              activeTab === tab.id
+                ? "bg-surface-raised text-default"
+                : "text-muted hover:text-secondary hover:bg-surface-raised/30",
+            )}
+          >
+            {tab.icon}
+            {tab.label}
+            {badge > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 h-3.5 min-w-[14px] px-0.5 rounded-full bg-danger text-[8px] font-bold text-on-emphasis flex items-center justify-center">
+                {badge}
+              </span>
+            )}
+          </button>
+        )
+      })}
     </div>
   )
 }
@@ -3616,7 +3818,10 @@ function ResizeHandle({
 
 export default function PrototypePage() {
   const bp = useBreakpoint()
+  const [agents, dispatchAgent] = useReducer(agentReducer, INITIAL_AGENTS)
+  const [feedItems, setFeedItems] = useState<TeamFeedItem[]>(TEAM_FEED)
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(["1"]))
+  const [focusedAgentId, setFocusedAgentId] = useState<string | null>("1")
   const [mainTab, setMainTab] = useState<"chat" | "agents" | "skills">("chat")
   const [secretsOpen, setSecretsOpen] = useState(false)
   const [agentPanelOpen, setAgentPanelOpen] = useState(true)
@@ -3636,15 +3841,52 @@ export default function PrototypePage() {
       else next.add(id)
       return next
     })
+    // Track focused agent + acknowledge review on expand
+    setFocusedAgentId(id)
+    dispatchAgent({ type: "ACKNOWLEDGE", agentId: id })
   }, [])
 
   const handleToggleExpandAll = useCallback(() => {
     setExpandedIds((prev) => {
-      const allOpen = AGENTS.every((a) => prev.has(a.id))
+      const allOpen = agents.every((a) => prev.has(a.id))
       if (allOpen) return new Set()
-      return new Set(AGENTS.map((a) => a.id))
+      return new Set(agents.map((a) => a.id))
     })
-  }, [])
+  }, [agents])
+
+  // Resolve a permission feed item → update feed + recompute agent attention
+  const handleResolvePermission = useCallback((feedIndex: number, verdict: "allowed" | "denied") => {
+    setFeedItems(prev => {
+      const next = [...prev]
+      const item = next[feedIndex]
+      if (item.type === "permission") {
+        next[feedIndex] = { ...item, permStatus: verdict }
+        // Recompute attention for this agent
+        const agentName = item.agent
+        const newAttention = deriveAttentionFromFeed(next, agentName)
+        dispatchAgent({ type: "SET_ATTENTION", agentId: agents.find(a => a.name === agentName)?.id ?? "", level: newAttention })
+      }
+      return next
+    })
+  }, [agents])
+
+  // Resolve a plan feed item → update feed + recompute agent attention
+  const handleResolvePlan = useCallback((feedIndex: number, verdict: "approved" | "rejected") => {
+    setFeedItems(prev => {
+      const next = [...prev]
+      const item = next[feedIndex]
+      if (item.type === "plan") {
+        next[feedIndex] = { ...item, planStatus: verdict }
+        const agentName = item.agent
+        const newAttention = deriveAttentionFromFeed(next, agentName)
+        dispatchAgent({ type: "SET_ATTENTION", agentId: agents.find(a => a.name === agentName)?.id ?? "", level: newAttention })
+      }
+      return next
+    })
+  }, [agents])
+
+  // Attention badge count for small-screen tab bar
+  const pendingCount = useMemo(() => getAllPendingItems(feedItems).length, [feedItems])
 
   // Determine what's visible at each breakpoint
   const showLeftPanel = bp !== "mobile"
@@ -3676,13 +3918,13 @@ export default function PrototypePage() {
       <SecretsModal
         open={secretsOpen}
         onClose={() => setSecretsOpen(false)}
-        agents={AGENTS}
+        agents={agents}
       />
 
       {/* Left panel: collapsed icon rail or open agent cards */}
       {showLeftPanel && (
         <AgentLeftPanel
-          agents={AGENTS}
+          agents={agents}
           expandedIds={expandedIds}
           onToggleAgent={handleToggleAgent}
           onToggleExpandAll={handleToggleExpandAll}
@@ -3692,6 +3934,9 @@ export default function PrototypePage() {
           width={effectiveLeftWidth}
           onResize={handleLeftPanelResize}
           onResetWidth={() => setLeftPanelWidth(null)}
+          feedItems={feedItems}
+          onResolvePermission={handleResolvePermission}
+          onResolvePlan={handleResolvePlan}
         />
       )}
 
@@ -3703,31 +3948,57 @@ export default function PrototypePage() {
             tabs={topTabs}
             activeTab={mainTab}
             onTabChange={(id) => setMainTab(id as "chat" | "agents" | "skills")}
+            badges={pendingCount > 0 ? { chat: pendingCount } : undefined}
           />
         )}
 
-        {/* Center: team feed */}
+        {/* Center: team feed + attention bar + composer */}
         {(!showTopTabs || mainTab === "chat") && (
           <main className="flex-1 min-w-0 flex flex-col min-h-0">
-            <TeamFeed />
+            <TeamFeed feedItems={feedItems} />
+            <AttentionBar
+              feedItems={feedItems}
+              focusedAgentId={focusedAgentId}
+              agents={agents}
+              onResolvePermission={handleResolvePermission}
+              onResolvePlan={handleResolvePlan}
+            />
+            <ComposerBar />
           </main>
         )}
 
         {/* Top-tab content: agents (S + mobile) */}
         {showTopTabs && mainTab === "agents" && (
-          <div className="flex-1 min-w-0 bg-surface">
+          <div className="flex-1 min-w-0 bg-surface flex flex-col">
             <AgentCardsPanel
-              agents={AGENTS}
+              agents={agents}
               expandedIds={expandedIds}
               onToggleAgent={handleToggleAgent}
+              feedItems={feedItems}
+              onResolvePermission={handleResolvePermission}
+              onResolvePlan={handleResolvePlan}
+            />
+            <AttentionBar
+              feedItems={feedItems}
+              focusedAgentId={focusedAgentId}
+              agents={agents}
+              onResolvePermission={handleResolvePermission}
+              onResolvePlan={handleResolvePlan}
             />
           </div>
         )}
 
         {/* Top-tab content: skills (S + mobile) */}
         {showTopTabs && mainTab === "skills" && (
-          <div className="flex-1 min-w-0 bg-surface overflow-hidden">
+          <div className="flex-1 min-w-0 bg-surface overflow-hidden flex flex-col">
             <SkillsPanel allExpanded={false} />
+            <AttentionBar
+              feedItems={feedItems}
+              focusedAgentId={focusedAgentId}
+              agents={agents}
+              onResolvePermission={handleResolvePermission}
+              onResolvePlan={handleResolvePlan}
+            />
           </div>
         )}
       </div>

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1695,6 +1695,13 @@ function AgentLeftPanel({
               <CheckSquare className="h-3 w-3" />
               {selectMode ? "Done" : "Select"}
             </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors shrink-0 text-muted hover:text-secondary hover:bg-surface-raised/50"
+            >
+              <Plus className="h-3 w-3" />
+              Create
+            </button>
           </div>
 
           {/* Agent cards */}
@@ -2570,14 +2577,24 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
   const [newTags, setNewTags] = useState<string[]>([])
   const [selectMode, setSelectMode] = useState(false)
   const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set())
+  const [skillTagFilter, setSkillTagFilter] = useState<string | null>(null)
+  const [showSkillTagDropdown, setShowSkillTagDropdown] = useState(false)
+
+  const allSkillTags = useMemo(() => Array.from(new Set(SKILLS.flatMap(s => s.assignedTags))).sort(), [])
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return SKILLS
-    const q = search.toLowerCase()
-    return SKILLS.filter(s =>
-      s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
-    )
-  }, [search])
+    let result = SKILLS
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      result = result.filter(s =>
+        s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
+      )
+    }
+    if (skillTagFilter) {
+      result = result.filter(s => s.assignedTags.includes(skillTagFilter))
+    }
+    return result
+  }, [search, skillTagFilter])
 
   return (
     <div className="flex flex-col h-full">
@@ -2592,6 +2609,49 @@ function SkillsPanel({ allExpanded }: { allExpanded: boolean }) {
             placeholder="Search skills..."
             className="flex-1 bg-transparent border-none outline-none text-[11px] text-default placeholder:text-muted/30 min-w-0"
           />
+        </div>
+        <div className="relative shrink-0">
+          <button
+            type="button"
+            onClick={() => setShowSkillTagDropdown(!showSkillTagDropdown)}
+            className={cn(
+              "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors",
+              skillTagFilter
+                ? "border-accent/30 bg-accent/10 text-accent"
+                : "border-border-default text-muted hover:text-secondary hover:bg-surface-raised/40",
+            )}
+          >
+            <Filter className="h-3 w-3" />
+            {skillTagFilter || "Tags"}
+            <ChevronRight size={10} className="rotate-90 text-muted/40" />
+          </button>
+          {showSkillTagDropdown && (
+            <div className="absolute top-full right-0 mt-1 w-32 rounded-md border border-border-default bg-surface-raised shadow-lg z-(--z-dropdown) overflow-hidden">
+              <button
+                type="button"
+                onClick={() => { setSkillTagFilter(null); setShowSkillTagDropdown(false) }}
+                className={cn(
+                  "w-full text-left px-3 py-1.5 text-[11px] transition-colors",
+                  !skillTagFilter ? "text-accent bg-accent/10" : "text-secondary hover:bg-surface-sunken/40",
+                )}
+              >
+                All tags
+              </button>
+              {allSkillTags.map(tag => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => { setSkillTagFilter(tag); setShowSkillTagDropdown(false) }}
+                  className={cn(
+                    "w-full text-left px-3 py-1.5 text-[11px] font-mono transition-colors",
+                    skillTagFilter === tag ? "text-accent bg-accent/10" : "text-secondary hover:bg-surface-sunken/40",
+                  )}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
         <button
           type="button"

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -1994,7 +1994,7 @@ function TagInput({
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && input.trim()) {
+          if ((e.key === "Enter" || e.key === " ") && input.trim()) {
             e.preventDefault()
             addTag(input.trim())
           }
@@ -2306,16 +2306,14 @@ function AgentCardRow({
           >
             {agent.name}
           </span>
-          {/* Tag pills — max 2 + overflow */}
+          {/* Tag pills — show 1 + overflow count */}
           {agent.tags.length > 0 && (
             <span className="inline-flex items-center gap-1 shrink-0">
-              {agent.tags.slice(0, 2).map((tag) => (
-                <span key={tag} className="px-1.5 py-px rounded text-[9px] font-mono text-muted bg-surface-sunken/60 border border-border-subtle">
-                  {tag}
-                </span>
-              ))}
-              {agent.tags.length > 2 && (
-                <span className="text-[9px] text-muted/40 font-mono">+{agent.tags.length - 2}</span>
+              <span className="px-1.5 py-px rounded text-[9px] font-mono text-muted bg-surface-sunken/60 border border-border-subtle">
+                {agent.tags[0]}
+              </span>
+              {agent.tags.length > 1 && (
+                <span className="text-[9px] text-muted/40 font-mono">+{agent.tags.length - 1}</span>
               )}
             </span>
           )}

--- a/dashboard/app/prototype/page.tsx
+++ b/dashboard/app/prototype/page.tsx
@@ -136,7 +136,7 @@ const INITIAL_AGENTS: FakeAgent[] = [
     id: "4",
     name: "devops",
     lifecycleStatus: "waiting",
-    attentionLevel: "none",
+    attentionLevel: "plan",
     task: "Waiting for backend",
     cost: 0.03,
     duration: "5m 00s",
@@ -483,6 +483,19 @@ const TEAM_FEED: TeamFeedItem[] = [
     command: "git push origin fix/jwt-validation",
     risk: "Pushes to remote branch",
     permStatus: "pending",
+  },
+
+  // Devops proposes a deployment plan
+  {
+    type: "plan",
+    agent: "devops",
+    title: "Deploy auth fix to staging",
+    steps: [
+      { text: "Build Docker image with auth changes", status: "done" as const },
+      { text: "Run integration tests in staging env", status: "current" as const },
+      { text: "Swap traffic to new deployment", status: "pending" as const },
+    ],
+    planStatus: "pending" as const,
   },
 
   // Docs finishes
@@ -2484,64 +2497,100 @@ function AttentionBar({
     return (order[a.item.type] ?? 2) - (order[b.item.type] ?? 2)
   })
 
+  // Stepper state — clamp to valid range when items resolve
+  const [stepIdx, setStepIdx] = useState(0)
+  const clamped = Math.min(stepIdx, sorted.length - 1)
+  const current = sorted[clamped]
+  const { item, feedIndex, agentId } = current
+  const isFocused = focusedAgentId != null && agentId === focusedAgentId
+  const hasPrev = clamped > 0
+  const hasNext = clamped < sorted.length - 1
+
   return (
     <div className="mx-6 mb-2 rounded-lg border border-warning/20 bg-warning-subtle/10 p-3 max-w-3xl self-center w-full">
+      {/* Header: icon + count + stepper nav */}
       <div className="flex items-center gap-2 mb-2">
         <AlertTriangle className="h-3.5 w-3.5 text-warning shrink-0" />
         <span className="text-xs font-medium text-warning">
-          {pending.length} item{pending.length !== 1 ? "s" : ""} need attention
+          {sorted.length} item{sorted.length !== 1 ? "s" : ""} need attention
         </span>
-      </div>
-      <div className="space-y-1.5">
-        {sorted.map(({ item, feedIndex, agentId }) => {
-          // Suppression: dim items for the focused agent
-          const isFocused = focusedAgentId != null && agentId === focusedAgentId
-          return (
-            <div key={feedIndex} className={cn("flex items-center gap-2 min-w-0", isFocused && "opacity-50")}>
-              <AgentAvatar name={item.agent} size="sm" />
-              <span className="text-[11px] text-secondary truncate flex-1 min-w-0">
-                {item.type === "permission"
-                  ? `${item.agent} wants to run: ${item.command}`
-                  : `${item.agent} proposed: ${item.title}`}
+        {sorted.length > 1 && (
+          <>
+            <span className="flex-1" />
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                disabled={!hasPrev}
+                onClick={() => setStepIdx(clamped - 1)}
+                className={cn(
+                  "p-0.5 rounded transition-colors",
+                  hasPrev ? "text-secondary hover:text-default hover:bg-surface-raised/50" : "text-muted/30 cursor-default",
+                )}
+              >
+                <ChevronLeft className="h-3 w-3" />
+              </button>
+              <span className="text-[10px] text-muted tabular-nums font-mono">
+                {clamped + 1}/{sorted.length}
               </span>
-              {item.type === "permission" ? (
-                <div className="flex items-center gap-1 shrink-0">
-                  <button
-                    type="button"
-                    onClick={() => onResolvePermission(feedIndex, "allowed")}
-                    className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-                  >
-                    Allow
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onResolvePermission(feedIndex, "denied")}
-                    className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-                  >
-                    Deny
-                  </button>
-                </div>
-              ) : (
-                <div className="flex items-center gap-1 shrink-0">
-                  <button
-                    type="button"
-                    onClick={() => onResolvePlan(feedIndex, "approved")}
-                    className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
-                  >
-                    Approve
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onResolvePlan(feedIndex, "rejected")}
-                    className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
-                  >
-                    Reject
-                  </button>
-                </div>
-              )}
+              <button
+                type="button"
+                disabled={!hasNext}
+                onClick={() => setStepIdx(clamped + 1)}
+                className={cn(
+                  "p-0.5 rounded transition-colors",
+                  hasNext ? "text-secondary hover:text-default hover:bg-surface-raised/50" : "text-muted/30 cursor-default",
+                )}
+              >
+                <ChevronRight className="h-3 w-3" />
+              </button>
             </div>
-          )
-        })}
+          </>
+        )}
+      </div>
+
+      {/* Current item */}
+      <div className={cn("flex items-center gap-2 min-w-0", isFocused && "opacity-50")}>
+        <AgentAvatar name={item.agent} size="sm" />
+        <span className="text-[11px] text-secondary truncate flex-1 min-w-0">
+          {item.type === "permission"
+            ? `${item.agent} wants to run: ${item.command}`
+            : `${item.agent} proposed: ${item.title}`}
+        </span>
+        {item.type === "permission" ? (
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => onResolvePermission(feedIndex, "allowed")}
+              className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+            >
+              Allow
+            </button>
+            <button
+              type="button"
+              onClick={() => onResolvePermission(feedIndex, "denied")}
+              className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+            >
+              Deny
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => onResolvePlan(feedIndex, "approved")}
+              className="px-2 py-1 rounded text-[10px] font-medium text-success border border-success/30 hover:bg-success-subtle/40 transition-colors"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={() => onResolvePlan(feedIndex, "rejected")}
+              className="px-2 py-1 rounded text-[10px] font-medium text-danger border border-danger/30 hover:bg-danger-subtle/40 transition-colors"
+            >
+              Reject
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Full dashboard prototype with 4-panel layout (sidebar, feed, composer, agent cards)
- Agent roster with 2-state cards, VNC preview, inline composer, bulk ops
- Team feed with 9 event types: system, user, summary, status, error, question, plan, permission, agent-to-agent messages
- Composer with recipient search (@agent, #tag), ghost text autocomplete, pill management
- Attention bar with inline plan review expansion (approve/reject without navigation)
- Responsive breakpoints: XL, L, M, S, mobile with tab-based navigation
- Resizable sidebar with snap-to-collapse
- Skills tab, tag editor, search/filter, select mode

## Test plan

- [ ] Visit /prototype at each breakpoint (resize browser)
- [ ] Click agent cards to expand/collapse, verify VNC + mini composer
- [ ] Type @agent in composer recipient search, verify autocomplete + pill creation
- [ ] Step through attention bar items, click Review on plan item
- [ ] Verify plan expands inline with Approve/Reject pinned at bottom
- [ ] Click agent avatars in feed to filter, verify feed filtering works